### PR TITLE
Grab Nightscout settings and units before SGV and delta are read

### DIFF
--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutCommand.kt
@@ -71,9 +71,9 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
         val dto = NightscoutDTO()
 
         try {
+            getSettings(endpoint, token, dto)
             getEntries(endpoint, token, dto)
             processPebble(endpoint, token, dto)
-            getSettings(endpoint, token, dto)
         } catch (exception: NoNightscoutDataException) {
             event.reactError()
             logger.info("No nightscout data from $endpoint")


### PR DESCRIPTION
Solves issue where deltas would be multiplied (converted to mg/dL) for Nightscout instances using Dexcom Share and mg/dL units