### PR TITLE
Fix minor bugs

### DIFF
--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminChannelsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminChannelsCommand.kt
@@ -65,15 +65,15 @@ class AdminChannelsCommand(category: Command.Category, parent: Command?) : Diabo
     private fun addChannel(event: CommandEvent) {
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
-        if (args.size != 3) {
+        if (args.size != 2) {
             throw IllegalArgumentException("Channel ID is required")
         }
 
-        if (!StringUtils.isNumeric(args[2])) {
+        if (!StringUtils.isNumeric(args[1])) {
             throw IllegalArgumentException("Channel ID must be numeric")
         }
 
-        val channelId = args[2]
+        val channelId = args[1]
 
         val channel = event.jda.getTextChannelById(channelId)
                 ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
@@ -86,15 +86,15 @@ class AdminChannelsCommand(category: Command.Category, parent: Command?) : Diabo
     private fun deleteChannel(event: CommandEvent) {
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
-        if (args.size != 3) {
+        if (args.size != 2) {
             throw IllegalArgumentException("Channel ID is required")
         }
 
-        if (!StringUtils.isNumeric(args[2])) {
+        if (!StringUtils.isNumeric(args[1])) {
             throw IllegalArgumentException("Channel ID must be numeric")
         }
 
-        val channelId = args[2]
+        val channelId = args[1]
 
         val channel = event.jda.getTextChannelById(channelId)
                 ?: throw IllegalArgumentException("Channel `$channelId` does not exist")

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutPublicCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutPublicCommand.kt
@@ -30,7 +30,7 @@ class NightscoutPublicCommand(category: Command.Category, parent: Command?) : Di
 
         val mode = args[0].toUpperCase()
 
-        if (mode == "TRUE" || mode == "T" || mode == "YES" || mode == "Y") {
+        if (mode == "TRUE" || mode == "T" || mode == "YES" || mode == "Y" || mode == "ON") {
             NightscoutDAO.getInstance().setNightscoutPublic(event.author, true)
             event.reply("Nightscout data for ${NicknameUtils.determineAuthorDisplayName(event)} set to public")
         } else {

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
@@ -5,6 +5,7 @@ import com.dongtronic.diabot.data.NightscoutDAO
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.core.entities.User
+import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
 import org.slf4j.LoggerFactory
 
 class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : DiabotCommand(category, parent) {
@@ -35,8 +36,12 @@ class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : Di
             event.replyError(ex.message)
         }
 
-        event.message.delete().reason("privacy").queue()
-        event.reply("Set Nightscout URL for ${event.author.name}")
+        try {
+            event.reply("Set Nightscout URL for ${event.author.name}")
+            event.message.delete().reason("privacy").queue()
+        } catch (ex: InsufficientPermissionException) {
+            event.replyError("Could not remove command message due to missing `manage messages` permission. Please remove the message yourself to protect your privacy.")
+        }
     }
 
     private fun validateNightscoutUrl(url: String): String {

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
@@ -32,12 +32,12 @@ class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : Di
 
         try {
             setNightscoutUrl(event.author, args[0])
+            event.reply("Set Nightscout URL for ${event.author.name}")
         } catch (ex: IllegalArgumentException) {
             event.replyError(ex.message)
         }
 
         try {
-            event.reply("Set Nightscout URL for ${event.author.name}")
             event.message.delete().reason("privacy").queue()
         } catch (ex: InsufficientPermissionException) {
             event.replyError("Could not remove command message due to missing `manage messages` permission. Please remove the message yourself to protect your privacy.")


### PR DESCRIPTION
- Admin channels command checked for the wrong number of arguments
- `diabot nightscout public` command mentioned using `on` as an argument in the example, but this was not treated as a valid argument
- `Set Nightscout URL` message would be sent even if the URL wasn't set (due to the URL not containing a scheme)
- `Set Nightscout URL` message would **not** be sent if the bot is unable to delete the message