### PR TITLE
Customizable NS cards

### DIFF
--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminChannelsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminChannelsCommand.kt
@@ -65,15 +65,15 @@ class AdminChannelsCommand(category: Command.Category, parent: Command?) : Diabo
     private fun addChannel(event: CommandEvent) {
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
-        if (args.size != 3) {
+        if (args.size != 2) {
             throw IllegalArgumentException("Channel ID is required")
         }
 
-        if (!StringUtils.isNumeric(args[2])) {
+        if (!StringUtils.isNumeric(args[1])) {
             throw IllegalArgumentException("Channel ID must be numeric")
         }
 
-        val channelId = args[2]
+        val channelId = args[1]
 
         val channel = event.jda.getTextChannelById(channelId)
                 ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
@@ -86,15 +86,15 @@ class AdminChannelsCommand(category: Command.Category, parent: Command?) : Diabo
     private fun deleteChannel(event: CommandEvent) {
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
-        if (args.size != 3) {
+        if (args.size != 2) {
             throw IllegalArgumentException("Channel ID is required")
         }
 
-        if (!StringUtils.isNumeric(args[2])) {
+        if (!StringUtils.isNumeric(args[1])) {
             throw IllegalArgumentException("Channel ID must be numeric")
         }
 
-        val channelId = args[2]
+        val channelId = args[1]
 
         val channel = event.jda.getTextChannelById(channelId)
                 ?: throw IllegalArgumentException("Channel `$channelId` does not exist")

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutCommand.kt
@@ -40,7 +40,8 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
                 NightscoutSetUrlCommand(category, this),
                 NightscoutDeleteCommand(category, this),
                 NightscoutPublicCommand(category, this),
-                NightscoutSetTokenCommand(category, this)
+                NightscoutSetTokenCommand(category, this),
+                NightscoutSetDisplayCommand(category, this)
         )
     }
 
@@ -67,7 +68,7 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
 
     }
 
-    private fun buildNightscoutResponse(endpoint: String, token: String?, avatarUrl: String?, event: CommandEvent) {
+    private fun buildNightscoutResponse(endpoint: String, token: String?, displayOpts: String?, avatarUrl: String?, event: CommandEvent) {
         val dto = NightscoutDTO()
 
         try {
@@ -95,7 +96,7 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
 
         val builder = EmbedBuilder()
 
-        buildResponse(dto, avatarUrl, builder)
+        buildResponse(dto, avatarUrl, displayOpts, builder)
 
         val embed = builder.build()
 
@@ -115,14 +116,16 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
         val endpoint = getNightscoutHost(event.author) + "/api/v1/"
 
         val token = getToken(event.author)
+        val displayOptions = getDisplayOptions(event.author)
 
-        buildNightscoutResponse(endpoint, token, event.author.avatarUrl, event)
+        buildNightscoutResponse(endpoint, token, displayOptions, event.author.avatarUrl, event)
     }
 
     private fun getUnstoredData(event: CommandEvent) {
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
         var avatarUrl: String? = null
         var token: String? = null
+        var displayOptions: String? = null
         val endpoint = when {
             event.event.message.mentionedUsers.size == 1 -> {
                 val user = event.event.message.mentionedMembers[0].user
@@ -146,10 +149,11 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
 
         if (event.message.mentionedUsers.size == 1 && !event.message.mentionsEveryone()) {
             token = getToken(event.message.mentionedUsers[0])
+            displayOptions = getDisplayOptions(event.message.mentionedUsers[0])
             avatarUrl = event.message.mentionedUsers[0].avatarUrl
         }
 
-        buildNightscoutResponse(endpoint, token, avatarUrl, event)
+        buildNightscoutResponse(endpoint, token, displayOptions, avatarUrl, event)
     }
 
     private fun processPebble(url: String, token: String?, dto: NightscoutDTO) {
@@ -178,8 +182,8 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
         }
     }
 
-    private fun buildResponse(dto: NightscoutDTO, avatarUrl: String?, builder: EmbedBuilder) {
-        builder.setTitle(dto.title)
+    private fun buildResponse(dto: NightscoutDTO, avatarUrl: String?, displayOpts: String?, builder: EmbedBuilder) {
+        if(displayOpts!!.contains("trend")) builder.setTitle(dto.title)
 
         val mmolString: String
         val mgdlString: String
@@ -194,17 +198,17 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
         val trendString = trendArrows[dto.trend]
         builder.addField("mmol/L", mmolString, true)
         builder.addField("mg/dL", mgdlString, true)
-        builder.addField("trend", trendString, true)
-        if (dto.iob != 0.0F) {
+        if(displayOpts.contains("trend")) builder.addField("trend", trendString, true)
+        if (dto.iob != 0.0F && displayOpts.contains("iob")) {
             builder.addField("iob", dto.iob.toString(), true)
         }
-        if (dto.cob != 0) {
+        if (dto.cob != 0 && displayOpts.contains("cob")) {
             builder.addField("cob", dto.cob.toString(), true)
         }
 
         setResponseColor(dto, builder)
 
-        if (avatarUrl != null) {
+        if (avatarUrl != null && displayOpts.contains("avatar")) {
             builder.setThumbnail(avatarUrl)
         }
 
@@ -417,5 +421,13 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
         }
 
         return null
+    }
+
+    private fun getDisplayOptions(user: User): String? {
+        if (NightscoutDAO.getInstance().isNightscoutDisplay(user)) {
+            return NightscoutDAO.getInstance().getNightscoutDisplay(user)
+        }
+        // if there are no options set in redis, then have the default be all options
+        return NightscoutSetDisplayCommand.validOptions.joinToString(" ")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutPublicCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutPublicCommand.kt
@@ -30,7 +30,7 @@ class NightscoutPublicCommand(category: Command.Category, parent: Command?) : Di
 
         val mode = args[0].toUpperCase()
 
-        if (mode == "TRUE" || mode == "T" || mode == "YES" || mode == "Y") {
+        if (mode == "TRUE" || mode == "T" || mode == "YES" || mode == "Y" || mode == "ON") {
             NightscoutDAO.getInstance().setNightscoutPublic(event.author, true)
             event.reply("Nightscout data for ${NicknameUtils.determineAuthorDisplayName(event)} set to public")
         } else {

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetDisplayCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetDisplayCommand.kt
@@ -1,0 +1,68 @@
+package com.dongtronic.diabot.commands.nightscout
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.util.NicknameUtils
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.core.entities.User
+import org.slf4j.LoggerFactory
+
+class NightscoutSetDisplayCommand(category: Command.Category, parent: Command?) : DiabotCommand(category, parent) {
+    companion object {
+        val validOptions = arrayOf("none", "title", "trend", "cob", "iob", "avatar")
+    }
+    private val logger = LoggerFactory.getLogger(NightscoutSetDisplayCommand::class.java)
+
+    init {
+        this.name = "display"
+        this.help = "Set display options for NS cards"
+        this.guildOnly = true
+        this.ownerCommand = false
+        this.aliases = arrayOf("setdisplay")
+        this.category = category
+        this.examples = arrayOf(this.parent!!.name + " display trend cob avatar", this.parent.name + " display reset (to reset)")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val nickname = NicknameUtils.determineAuthorDisplayName(event)
+
+        when {
+            args.size == 1 && args[0] == "reset" -> {
+                resetNightscoutDisplay(event.author)
+                event.replySuccess("Reset Nightscout display options for $nickname")
+            }
+
+            args.isNotEmpty() -> {
+                // Prioritize `none` option over any others provided
+                val options = if(args.contains("none")) arrayOf("none") else args
+
+                // verify options and set
+                for(opt in options) {
+                    if(!validOptions.contains(opt.toLowerCase())) {
+                        event.replyError("Unsupported display option provided, use `diabot nightscout display` to see possible options")
+                        return
+                    }
+                }
+
+                setNightscoutDisplay(event.author, options.joinToString(" "))
+                event.replySuccess("Nightscout display options for $nickname set to: " +
+                        options.joinToString(" ", "`", "`"))
+            }
+
+            else -> event.reply("Possible display options: " +
+                    validOptions.joinToString("`, `", "`", "`"))
+        }
+    }
+
+    private fun setNightscoutDisplay(user: User, options: String) {
+        logger.info("Setting NS display options for ${user.name} to: $options")
+        NightscoutDAO.getInstance().setNightscoutDisplay(user, options)
+    }
+
+    private fun resetNightscoutDisplay(user: User) {
+        logger.info("Resetting NS display options for ${user.name}")
+        NightscoutDAO.getInstance().setNightscoutDisplay(user, "")
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
@@ -5,6 +5,7 @@ import com.dongtronic.diabot.data.NightscoutDAO
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.core.entities.User
+import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
 import org.slf4j.LoggerFactory
 
 class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : DiabotCommand(category, parent) {
@@ -35,8 +36,12 @@ class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : Di
             event.replyError(ex.message)
         }
 
-        event.message.delete().reason("privacy").queue()
-        event.reply("Set Nightscout URL for ${event.author.name}")
+        try {
+            event.reply("Set Nightscout URL for ${event.author.name}")
+            event.message.delete().reason("privacy").queue()
+        } catch (ex: InsufficientPermissionException) {
+            event.replyError("Could not remove command message due to missing `manage messages` permission. Please remove the message yourself to protect your privacy.")
+        }
     }
 
     private fun validateNightscoutUrl(url: String): String {

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
@@ -32,12 +32,12 @@ class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : Di
 
         try {
             setNightscoutUrl(event.author, args[0])
+            event.reply("Set Nightscout URL for ${event.author.name}")
         } catch (ex: IllegalArgumentException) {
             event.replyError(ex.message)
         }
 
         try {
-            event.reply("Set Nightscout URL for ${event.author.name}")
             event.message.delete().reason("privacy").queue()
         } catch (ex: InsufficientPermissionException) {
             event.replyError("Could not remove command message due to missing `manage messages` permission. Please remove the message yourself to protect your privacy.")

--- a/src/main/java/com/dongtronic/diabot/data/NightscoutDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/NightscoutDAO.kt
@@ -53,6 +53,28 @@ class NightscoutDAO private constructor() {
         }
     }
 
+    fun isNightscoutDisplay(user: User): Boolean {
+        val redisKey = RedisKeyFormats.nightscoutDisplayFormat.replace("{{userid}}", user.id)
+
+        return !jedis!!.get(redisKey).isNullOrEmpty()
+    }
+
+    fun getNightscoutDisplay(user: User): String {
+        val redisKey = RedisKeyFormats.nightscoutDisplayFormat.replace("{{userid}}", user.id)
+
+        return jedis!!.get(redisKey).toString()
+    }
+
+    fun setNightscoutDisplay(user: User, display: String) {
+        val redisKey = RedisKeyFormats.nightscoutDisplayFormat.replace("{{userid}}", user.id)
+
+        if (display.isNotEmpty()) {
+            jedis!!.set(redisKey, display)
+        } else {
+            jedis!!.del(redisKey)
+        }
+    }
+
     fun isNightscoutToken(user: User): Boolean {
         val redisKey = RedisKeyFormats.nightscoutTokenFormat.replace("{{userid}}", user.id)
 

--- a/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
+++ b/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
@@ -4,6 +4,7 @@ object RedisKeyFormats {
     const val nightscoutUrlFormat = "{{userid}}:nightscouturl"
     const val nightscoutPublicFormat = "{{userid}}:nightscoutprivate"
     const val nightscoutTokenFormat = "{{userid}}:nightscouttoken"
+    const val nightscoutDisplayFormat = "{{userid}}:nightscoutdisplay"
     const val allNightscoutUrlsFormat = "*:nightscouturl"
     const val adminChannelIds = "{{guildid}}:adminchannels"
     const val simpleRewards = "{{guildid}}:simplerewards"


### PR DESCRIPTION
Closes #39 
Adds a command that allows users to toggle individual components in their `diabot nightscout` cards through the use of the `diabot ns display` command. Currently available components are `title, trend, cob, iob, avatar`