### PR TITLE
Add support for project info commands (#58)

### DIFF
--- a/src/main/java/com/dongtronic/diabot/Main.kt
+++ b/src/main/java/com/dongtronic/diabot/Main.kt
@@ -5,6 +5,7 @@ import com.dongtronic.diabot.commands.admin.RolesCommand
 import com.dongtronic.diabot.commands.admin.ShutdownCommand
 import com.dongtronic.diabot.commands.diabetes.ConvertCommand
 import com.dongtronic.diabot.commands.diabetes.EstimationCommand
+import com.dongtronic.diabot.commands.info.InfoCommand
 import com.dongtronic.diabot.commands.misc.*
 import com.dongtronic.diabot.commands.nightscout.NightscoutAdminCommand
 import com.dongtronic.diabot.commands.nightscout.NightscoutCommand
@@ -18,7 +19,6 @@ import net.dv8tion.jda.core.JDABuilder
 import net.dv8tion.jda.core.OnlineStatus
 import net.dv8tion.jda.core.Permission
 import net.dv8tion.jda.core.entities.Game
-import org.slf4j.LoggerFactory
 import javax.security.auth.login.LoginException
 
 object Main {
@@ -37,6 +37,7 @@ object Main {
         val a1cCategory = Category("A1c estimations")
         val funCategory = Category("Fun")
         val utilitiesCategory = Category("Utilities")
+        val infoCategory = Category("Informative")
 
         // define an eventwaiter, dont forget to add this to the JDABuilder!
         val waiter = EventWaiter()
@@ -80,6 +81,9 @@ object Main {
                 RewardsCommand(utilitiesCategory),
                 GithubCommand(utilitiesCategory),
                 DisclaimerCommand(utilitiesCategory),
+
+                // Info
+                InfoCommand(infoCategory),
 
                 // Fun
                 ExcuseCommand(funCategory),

--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminCommand.kt
@@ -36,8 +36,4 @@ class AdminCommand(category: Command.Category) : DiabotCommand(category, null) {
         event.replyError("Unknown command: ${args[0]}")
 
     }
-
-
-
-
 }

--- a/src/main/java/com/dongtronic/diabot/commands/info/InfoCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/info/InfoCommand.kt
@@ -36,10 +36,6 @@ class InfoCommand(category: Category) : DiabotCommand(category, null) {
 
             val text = InfoDAO.getInstance().getProjectText(project)
 
-            if (text == null) {
-                throw IllegalArgumentException("Project $project does not exist")
-            }
-
             val builder = EmbedBuilder()
 
             builder.setTitle(InfoDAO.getInstance().formatProject(project))

--- a/src/main/java/com/dongtronic/diabot/commands/info/InfoCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/info/InfoCommand.kt
@@ -1,0 +1,53 @@
+package com.dongtronic.diabot.commands.info
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.InfoDAO
+import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.core.EmbedBuilder
+import org.slf4j.LoggerFactory
+
+class InfoCommand(category: Category) : DiabotCommand(category, null) {
+
+    private val logger = LoggerFactory.getLogger(InfoCommand::class.java)
+
+    init {
+        this.name = "info"
+        this.help = "Project Information. Administrators can add new projects"
+        this.guildOnly = false
+        this.aliases = arrayOf("i")
+        this.examples = arrayOf()
+        this.children = arrayOf(
+                InfoSetCommand(category, this),
+                InfoListCommand(category, this),
+                InfoDeleteCommand(category, this))
+    }
+
+    override fun execute(event: CommandEvent) {
+        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+        if (args.isEmpty()) {
+            // List all available projects
+            event.replyError("Please specify a command")
+            return
+        }
+
+        try {
+            val project = args[0]
+
+            val text = InfoDAO.getInstance().getProjectText(project)
+
+            if (text == null) {
+                throw IllegalArgumentException("Project $project does not exist")
+            }
+
+            val builder = EmbedBuilder()
+
+            builder.setTitle(InfoDAO.getInstance().formatProject(project))
+            builder.setDescription(text)
+
+            event.reply(builder.build())
+        } catch (ex: Exception) {
+            event.replyError(ex.message)
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/info/InfoDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/info/InfoDeleteCommand.kt
@@ -14,7 +14,7 @@ class InfoDeleteCommand(category: Command.Category, parent: Command) : DiabotCom
 
     init {
         this.name = "delete"
-        this.help = "Delete project informaiton"
+        this.help = "Delete project information"
         this.guildOnly = true
         this.aliases = arrayOf("d", "del", "rem", "remove")
         this.userPermissions = arrayOf(Permission.MANAGE_CHANNEL)
@@ -32,7 +32,6 @@ class InfoDeleteCommand(category: Command.Category, parent: Command) : DiabotCom
             val args = event.args.split("[^\\S\r\n]".toRegex()).dropLastWhile { it.isEmpty() }.toList()
 
             if (args.size != 1) {
-                // List all available projects
                 event.replyError("Valid syntax: `diabot info delete [project]`")
                 return
             }

--- a/src/main/java/com/dongtronic/diabot/commands/info/InfoDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/info/InfoDeleteCommand.kt
@@ -1,0 +1,49 @@
+package com.dongtronic.diabot.commands.info
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.InfoDAO
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.core.Permission
+import org.slf4j.LoggerFactory
+import java.lang.Exception
+
+class InfoDeleteCommand(category: Command.Category, parent: Command) : DiabotCommand(category, parent) {
+
+    private val logger = LoggerFactory.getLogger(InfoDeleteCommand::class.java)
+
+    init {
+        this.name = "delete"
+        this.help = "Delete project informaiton"
+        this.guildOnly = true
+        this.aliases = arrayOf("d", "del", "rem", "remove")
+        this.userPermissions = arrayOf(Permission.MANAGE_CHANNEL)
+        this.examples = arrayOf(this.getName() + " openaps")
+    }
+
+    override fun execute(event: CommandEvent) {
+        try {
+            // This command may exclusively be run on the official Diabetes server.
+            if (event.guild.id != "257554742371155998") {
+                event.replyError("This command can only be executed on the official r/Diabetes Discord server. https://discord.gg/diabetes")
+                return
+            }
+
+            val args = event.args.split("[^\\S\r\n]".toRegex()).dropLastWhile { it.isEmpty() }.toList()
+
+            if (args.size != 1) {
+                // List all available projects
+                event.replyError("Valid syntax: `diabot info delete [project]`")
+                return
+            }
+
+            val project = args[0]
+
+            InfoDAO.getInstance().removeProject(project)
+
+            event.replySuccess("Deleted project info for $project")
+        } catch (ex : Exception) {
+            event.replyError(ex.message)
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/info/InfoListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/info/InfoListCommand.kt
@@ -1,0 +1,47 @@
+package com.dongtronic.diabot.commands.info
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.InfoDAO
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.core.EmbedBuilder
+import net.dv8tion.jda.core.entities.MessageEmbed
+import org.slf4j.LoggerFactory
+import java.lang.Exception
+
+class InfoListCommand(category: Category, parent: Command) : DiabotCommand(category, parent) {
+
+    private val logger = LoggerFactory.getLogger(InfoListCommand::class.java)
+
+    init {
+        this.name = "list"
+        this.help = "List projects"
+        this.guildOnly = false
+        this.aliases = arrayOf("l", "ls")
+        this.examples = arrayOf(this.getName())
+    }
+
+    override fun execute(event: CommandEvent) {
+        try {
+            val args = event.args.split("[^\\S\r\n]".toRegex()).dropLastWhile { it.isEmpty() }.toList()
+
+            if (args.isNotEmpty()) {
+                // List all available projects
+                event.replyError("Valid syntax: `diabot info list`")
+                return
+            }
+
+            val projects = InfoDAO.getInstance().listProjects()
+
+            val builder = EmbedBuilder()
+
+            builder.setTitle("Available Projects")
+            builder.addField(MessageEmbed.Field("Help", "Use `diabot info [project]` to get information about a project", false))
+            builder.setDescription(projects.sorted().joinToString("\n"))
+
+            event.reply(builder.build())
+        } catch (ex : Exception) {
+            event.replyError(ex.message)
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/info/InfoListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/info/InfoListCommand.kt
@@ -26,7 +26,6 @@ class InfoListCommand(category: Category, parent: Command) : DiabotCommand(categ
             val args = event.args.split("[^\\S\r\n]".toRegex()).dropLastWhile { it.isEmpty() }.toList()
 
             if (args.isNotEmpty()) {
-                // List all available projects
                 event.replyError("Valid syntax: `diabot info list`")
                 return
             }

--- a/src/main/java/com/dongtronic/diabot/commands/info/InfoSetCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/info/InfoSetCommand.kt
@@ -1,0 +1,56 @@
+package com.dongtronic.diabot.commands.info
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.InfoDAO
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.core.Permission
+import org.slf4j.LoggerFactory
+import java.lang.Exception
+
+class InfoSetCommand(category: Command.Category, parent: Command) : DiabotCommand(category, parent) {
+
+    private val logger = LoggerFactory.getLogger(InfoSetCommand::class.java)
+
+    init {
+        this.name = "set"
+        this.help = "Set project information"
+        this.guildOnly = true
+        this.aliases = arrayOf("s")
+        this.userPermissions = arrayOf(Permission.MANAGE_CHANNEL)
+        this.examples = arrayOf(this.getName() + " openaps openaps is a project for ...")
+    }
+
+    override fun execute(event: CommandEvent) {
+        try {
+            // This command may exclusively be run on the official Diabetes server.
+            if (event.guild.id != "257554742371155998") {
+                event.replyError("This command can only be executed on the official r/Diabetes Discord server. https://discord.gg/diabetes")
+                return
+            }
+
+            val args = event.args.split("[^\\S\r\n]".toRegex()).dropLastWhile { it.isEmpty() }.toList()
+
+            if (args.isEmpty() || args.size < 2) {
+                // List all available projects
+                event.replyError("Valid syntax: `diabot info set [project] [description]`")
+                return
+            }
+
+            val project = args[0]
+
+            if (project.toUpperCase() == "PROJECT" || project.toUpperCase() == "PROJECTS") {
+                // protect database key
+                throw IllegalArgumentException("Project name $project is forbidden")
+            }
+
+            val description = args.reversed().dropLast(1).reversed().joinToString(" ")
+
+            InfoDAO.getInstance().setProjectText(project, description)
+
+            event.replySuccess("Description for $project updated")
+        } catch (ex : Exception) {
+            event.replyError(ex.message)
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/info/InfoSetCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/info/InfoSetCommand.kt
@@ -32,7 +32,6 @@ class InfoSetCommand(category: Command.Category, parent: Command) : DiabotComman
             val args = event.args.split("[^\\S\r\n]".toRegex()).dropLastWhile { it.isEmpty() }.toList()
 
             if (args.isEmpty() || args.size < 2) {
-                // List all available projects
                 event.replyError("Valid syntax: `diabot info set [project] [description]`")
                 return
             }

--- a/src/main/java/com/dongtronic/diabot/data/InfoDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/InfoDAO.kt
@@ -64,7 +64,7 @@ class InfoDAO private constructor() {
         jedis!!.del(textKey)
     }
 
-    fun getProjectText(project: String): String? {
+    fun getProjectText(project: String): String {
         val properName = formatProject(project)
 
         if (properName == null) {
@@ -73,7 +73,7 @@ class InfoDAO private constructor() {
 
         val key = RedisKeyFormats.infoText.replace("{{project}}", properName)
 
-        return jedis!!.get(key);
+        return jedis!!.get(key)
     }
 
     fun setProjectText(project: String, description: String) {

--- a/src/main/java/com/dongtronic/diabot/data/InfoDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/InfoDAO.kt
@@ -1,0 +1,106 @@
+package com.dongtronic.diabot.data
+
+import com.dongtronic.diabot.util.RedisKeyFormats
+import org.slf4j.LoggerFactory
+import redis.clients.jedis.Jedis
+import kotlin.IllegalArgumentException
+
+class InfoDAO private constructor() {
+    private var jedis: Jedis? = null
+    private val logger = LoggerFactory.getLogger(InfoDAO::class.java)
+
+
+    init {
+        if (System.getenv("REDIS_URL") != null) {
+            jedis = Jedis(System.getenv("REDIS_URL"))
+        } else if (System.getenv("DIABOT_REDIS_URL") != null) {
+            jedis = Jedis(System.getenv("DIABOT_REDIS_URL"))
+        }
+    }
+
+    fun listProjects(): MutableList<String> {
+        val key = RedisKeyFormats.infoList
+
+        val projectListLength = jedis!!.llen(key)
+
+        return jedis!!.lrange(key, 0, projectListLength - 1)
+    }
+
+    fun formatProject(project: String): String? {
+        val projects = listProjects()
+
+        projects.forEach{foundProject ->
+            if (foundProject.toUpperCase() == project.toUpperCase()) {
+                return foundProject
+            }
+        }
+
+        return null
+    }
+
+    fun findProject(project: String): Int {
+        val projects = listProjects()
+
+        projects.forEach{foundProject ->
+            if (foundProject.toUpperCase() == project.toUpperCase()) {
+                return projects.indexOf(foundProject)
+            }
+        }
+
+        return -1
+    }
+
+    fun removeProject(project: String) {
+        val key = RedisKeyFormats.infoList
+
+        if (findProject(project) == -1) {
+            throw IllegalArgumentException("Project $project is not configured")
+        }
+
+        val properName = formatProject(project)
+        val textKey = RedisKeyFormats.infoText.replace("{{project}}", properName!!)
+
+        jedis!!.lrem(key, 0, properName)
+        jedis!!.del(textKey)
+    }
+
+    fun getProjectText(project: String): String? {
+        val properName = formatProject(project)
+
+        if (properName == null) {
+            throw IllegalArgumentException("Project $project does not exist")
+        }
+
+        val key = RedisKeyFormats.infoText.replace("{{project}}", properName)
+
+        return jedis!!.get(key);
+    }
+
+    fun setProjectText(project: String, description: String) {
+        val exists = findProject(project) != -1
+
+        if (exists) {
+            // update existing project
+            val properName = formatProject(project)
+            val textKey = RedisKeyFormats.infoText.replace("{{project}}", properName!!)
+            jedis!!.set(textKey, description)
+        } else {
+            // create new project
+            val listKey = RedisKeyFormats.infoList
+            val textKey = RedisKeyFormats.infoText.replace("{{project}}", project)
+            jedis!!.lpush(listKey, project)
+            jedis!!.set(textKey, description)
+        }
+    }
+
+    companion object {
+        private var instance: InfoDAO? = null
+
+        fun getInstance(): InfoDAO {
+            if (instance == null) {
+                instance = InfoDAO()
+            }
+            return instance as InfoDAO
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
+++ b/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
@@ -1,6 +1,7 @@
 package com.dongtronic.diabot.util
 
 object RedisKeyFormats {
+    // Nightscout
     const val nightscoutUrlFormat = "{{userid}}:nightscouturl"
     const val nightscoutPublicFormat = "{{userid}}:nightscoutprivate"
     const val nightscoutTokenFormat = "{{userid}}:nightscouttoken"
@@ -8,17 +9,26 @@ object RedisKeyFormats {
     const val allNightscoutUrlsFormat = "*:nightscouturl"
     const val nightscoutShortChannelsFormat = "{{guildid}}:nightscoutshortchannels"
 
+    // Admin
     const val adminChannelIds = "{{guildid}}:adminchannels"
+
+    // Rewards
     const val simpleRewards = "{{guildid}}:simplerewards"
     const val rewardOptout = "{{guildid}}:rewardoptouts"
 
+    // Usernames
     const val usernamePattern = "{{guildid}}:usernamepattern"
     const val enforceUsernames = "{{guildid}}:enforceusernames"
     const val usernameHint = "{{guildid}}:usernamehint"
 
+    // Rules
     const val ruleIds = "{{guildid}}:rules"
     const val rulesChannel = "{{guildid}}:ruleschannel"
     const val ruleText = "{{guildid}}:rules:{{ruleid}}:text"
     const val ruleTitle = "{{guildid}}:rules:{{ruleid}}:title"
     const val ruleMessage = "{{guildid}}:rules:{{ruleid}}:message"
+
+    // Project info
+    const val infoList = "info:projects"
+    const val infoText = "info:{{project}}"
 }


### PR DESCRIPTION
Close #58

Adds new commands:

* diabot info list
* diabot info set [project] [description] (automatically adds new projects)
* diabot info delete [project]
* diabot info [project]

Commands that set or delete projects can only be executed by users with the `Manage Messages` privilege on the r/diabetes discord server as project info is shared globally.