### PR TITLE
Add opt-in simplified option for the Nightscout display

### DIFF
--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutCommand.kt
@@ -99,7 +99,7 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
         }
 
         val shortReply = NightscoutDAO.getInstance().listShortChannels(event.guild.id).contains(event.channel.id) ||
-                         userDTO.displayOptions.contains("simplified")
+                         userDTO.displayOptions.contains("simple")
 
         if (shortReply) {
             val message = buildShortResponse(dto, userDTO.displayOptions)

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutCommand.kt
@@ -98,7 +98,8 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
             return
         }
 
-        val shortReply = NightscoutDAO.getInstance().listShortChannels(event.guild.id).contains(event.channel.id)
+        val shortReply = NightscoutDAO.getInstance().listShortChannels(event.guild.id).contains(event.channel.id) ||
+                         userDTO.displayOptions.contains("simplified")
 
         if (shortReply) {
             val message = buildShortResponse(dto, userDTO.displayOptions)
@@ -578,6 +579,6 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
      * Provides display options with everything enabled
      */
     private fun getDefaultDisplayOptions(): Array<String> {
-        return NightscoutSetDisplayCommand.validOptions
+        return NightscoutSetDisplayCommand.enabledOptions
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetDisplayCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetDisplayCommand.kt
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory
 class NightscoutSetDisplayCommand(category: Command.Category, parent: Command?) : DiabotCommand(category, parent) {
     companion object {
         val enabledOptions = arrayOf("title", "trend", "cob", "iob", "avatar")
-        val validOptions = enabledOptions.plus(arrayOf("simplified", "none"))
+        val validOptions = enabledOptions.plus(arrayOf("simple", "none"))
     }
 
     private val logger = LoggerFactory.getLogger(NightscoutSetDisplayCommand::class.java)

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetDisplayCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetDisplayCommand.kt
@@ -10,7 +10,8 @@ import org.slf4j.LoggerFactory
 
 class NightscoutSetDisplayCommand(category: Command.Category, parent: Command?) : DiabotCommand(category, parent) {
     companion object {
-        val validOptions = arrayOf("none", "title", "trend", "cob", "iob", "avatar")
+        val enabledOptions = arrayOf("title", "trend", "cob", "iob", "avatar")
+        val validOptions = enabledOptions.plus(arrayOf("simplified", "none"))
     }
 
     private val logger = LoggerFactory.getLogger(NightscoutSetDisplayCommand::class.java)


### PR DESCRIPTION
This adds a simplified option to the "diabot ns display" command, also separated the options that are enabled by default from the valid ones, so the simplified option doesn't apply by default. Closes #71