### PR TITLE
Command Improvements

### DIFF
--- a/src/main/java/com/dongtronic/diabot/Main.kt
+++ b/src/main/java/com/dongtronic/diabot/Main.kt
@@ -9,6 +9,7 @@ import com.dongtronic.diabot.commands.info.InfoCommand
 import com.dongtronic.diabot.commands.misc.*
 import com.dongtronic.diabot.commands.nightscout.NightscoutAdminCommand
 import com.dongtronic.diabot.commands.nightscout.NightscoutCommand
+import com.dongtronic.diabot.commands.rewards.RewardsCommand
 import com.dongtronic.diabot.listener.*
 import com.jagrosh.jdautilities.command.Command.Category
 import com.jagrosh.jdautilities.command.CommandClientBuilder

--- a/src/main/java/com/dongtronic/diabot/commands/SampleCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/SampleCommand.kt
@@ -16,6 +16,7 @@ class SampleCommand(category: Command.Category, parent: Command?) : DiabotComman
         this.ownerCommand = false
         this.aliases = arrayOf("tast", "tost")
         this.userPermissions = arrayOf(Permission.ADMINISTRATOR)
+        this.children = arrayOf(SampleSubCommand(category, this))
         this.hidden = true
     }
 

--- a/src/main/java/com/dongtronic/diabot/commands/SampleSubCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/SampleSubCommand.kt
@@ -24,14 +24,8 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiabotCom
     }
 
     override fun execute(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-
-        if (args.isEmpty()) {
-            event.replyError("must include operation")
-            return
-        }
-
-        event.replyError("Unknown command: `${args[0]}`")
+        val subcommands = children.joinToString(", ") { it.name }
+        event.replyError("Valid sub-commands are: $subcommands")
     }
 
     class SampleListSubCommand(category: Category, parent: Command?) : DiabotCommand(category, parent) {

--- a/src/main/java/com/dongtronic/diabot/commands/SampleSubCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/SampleSubCommand.kt
@@ -16,6 +16,11 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiabotCom
         this.aliases = arrayOf("s")
         this.category = category
         this.examples = arrayOf(this.parent!!.name + " sub")
+        this.children = arrayOf(
+                SampleListSubCommand(category, this),
+                SampleAddSubCommand(category, this),
+                SampleDeleteSubCommand(category, this)
+        )
     }
 
     override fun execute(event: CommandEvent) {
@@ -26,32 +31,51 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiabotCom
             return
         }
 
-        val command = args[0].toUpperCase()
+        event.replyError("Unknown command: `${args[0]}`")
+    }
 
-        try {
-            when (command) {
-                "LIST", "L" -> someAction(event)
-                "ADD", "A" -> anotherAction(event)
-                "DELETE", "REMOVE", "D", "R" -> thirdAction(event)
-                else -> {
-                    throw IllegalArgumentException("unknown command $command")
-                }
-            }
+    class SampleListSubCommand(category: Category, parent: Command?) : DiabotCommand(category, parent) {
+        private val logger = LoggerFactory.getLogger(SampleListSubCommand::class.java)
 
-        } catch (ex: IllegalArgumentException) {
-            event.replyError(ex.message)
+        init {
+            this.name = "list"
+            this.help = "an example list subcommand"
+            this.guildOnly = false
+            this.aliases = arrayOf("l")
+        }
+
+        override fun execute(event: CommandEvent?) {
+            // do a thing
         }
     }
 
-    private fun someAction(event: CommandEvent) {
-        // do a thing
+    class SampleAddSubCommand(category: Category, parent: Command?) : DiabotCommand(category, parent) {
+        private val logger = LoggerFactory.getLogger(SampleAddSubCommand::class.java)
+
+        init {
+            this.name = "add"
+            this.help = "an example add subcommand"
+            this.guildOnly = false
+            this.aliases = arrayOf("a")
+        }
+
+        override fun execute(event: CommandEvent?) {
+            // do another thing
+        }
     }
 
-    private fun anotherAction(event: CommandEvent) {
-        // do another thing
-    }
+    class SampleDeleteSubCommand(category: Category, parent: Command?) : DiabotCommand(category, parent) {
+        private val logger = LoggerFactory.getLogger(SampleDeleteSubCommand::class.java)
 
-    private fun thirdAction(event: CommandEvent) {
-        // do the third thing
+        init {
+            this.name = "delete"
+            this.help = "an example delete subcommand"
+            this.guildOnly = false
+            this.aliases = arrayOf("remove", "d", "r")
+        }
+
+        override fun execute(event: CommandEvent?) {
+            // do the third thing
+        }
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminChannelsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminChannelsCommand.kt
@@ -1,11 +1,11 @@
 package com.dongtronic.diabot.commands.admin
 
 import com.dongtronic.diabot.commands.DiabotCommand
-import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.commands.admin.channels.AdminChannelAddCommand
+import com.dongtronic.diabot.commands.admin.channels.AdminChannelDeleteCommand
+import com.dongtronic.diabot.commands.admin.channels.AdminChannelListCommand
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import net.dv8tion.jda.api.EmbedBuilder
-import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
 
 class AdminChannelsCommand(category: Command.Category, parent: Command?) : DiabotCommand(category, parent) {
@@ -19,6 +19,11 @@ class AdminChannelsCommand(category: Command.Category, parent: Command?) : Diabo
         this.ownerCommand = false
         this.aliases = arrayOf("c")
         this.examples = arrayOf("diabot admin channels add <channelId>", "diabot admin channels delete <channelId>", "diabot admin channels list")
+        this.children = arrayOf(
+                AdminChannelAddCommand(category, this),
+                AdminChannelDeleteCommand(category, this),
+                AdminChannelListCommand(category, this)
+        )
     }
 
     override fun execute(event: CommandEvent) {
@@ -29,79 +34,6 @@ class AdminChannelsCommand(category: Command.Category, parent: Command?) : Diabo
             return
         }
 
-        val command = args[0].toUpperCase()
-
-        try {
-            when (command) {
-                "LIST", "L" -> listChannels(event)
-                "ADD", "A" -> addChannel(event)
-                "DELETE", "REMOVE", "D", "R" -> deleteChannel(event)
-                else -> {
-                    throw IllegalArgumentException("unknown command $command")
-                }
-            }
-
-        } catch (ex: IllegalArgumentException) {
-            event.replyError(ex.message)
-        }
-    }
-
-    private fun listChannels(event: CommandEvent) {
-        val channels = AdminDAO.getInstance().listAdminChannels(event.guild.id)
-
-        val builder = EmbedBuilder()
-
-        builder.setTitle("Admin channels")
-
-        for (channelId in channels!!) {
-            val channel = event.jda.getTextChannelById(channelId)
-
-            builder.appendDescription("**${channel!!.name}** (`${channel.id}`)\n")
-        }
-
-        event.reply(builder.build())
-    }
-
-    private fun addChannel(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-
-        if (args.size != 2) {
-            throw IllegalArgumentException("Channel ID is required")
-        }
-
-        if (!StringUtils.isNumeric(args[1])) {
-            throw IllegalArgumentException("Channel ID must be numeric")
-        }
-
-        val channelId = args[1]
-
-        val channel = event.jda.getTextChannelById(channelId)
-                ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
-
-        AdminDAO.getInstance().addAdminChannel(event.guild.id, channelId)
-
-        event.reply("Added admin channel ${channel.name} (`$channelId`)")
-    }
-
-    private fun deleteChannel(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-
-        if (args.size != 2) {
-            throw IllegalArgumentException("Channel ID is required")
-        }
-
-        if (!StringUtils.isNumeric(args[1])) {
-            throw IllegalArgumentException("Channel ID must be numeric")
-        }
-
-        val channelId = args[1]
-
-        val channel = event.jda.getTextChannelById(channelId)
-                ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
-
-        AdminDAO.getInstance().removeAdminChannel(event.guild.id, channelId)
-
-        event.reply("Removed admin channel ${channel.name} (`$channelId`)")
-
+        event.replyError("Unknown command: `${args[0]}`")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminChannelsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminChannelsCommand.kt
@@ -27,13 +27,7 @@ class AdminChannelsCommand(category: Command.Category, parent: Command?) : Diabo
     }
 
     override fun execute(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-
-        if (args.isEmpty()) {
-            event.replyError("must include operation")
-            return
-        }
-
-        event.replyError("Unknown command: `${args[0]}`")
+        val subcommands = children.joinToString(", ") { it.name }
+        event.replyError("Valid sub-commands are: $subcommands")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminCommand.kt
@@ -25,14 +25,7 @@ class AdminCommand(category: Command.Category) : DiabotCommand(category, null) {
     }
 
     override fun execute(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-
-        if (args.isEmpty()) {
-            event.replyError("Please specify a command")
-            return
-        }
-
-        event.replyError("Unknown command: ${args[0]}")
-
+        val subcommands = children.joinToString(", ") { it.name }
+        event.replyError("Valid sub-commands are: $subcommands")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminRewardsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminRewardsCommand.kt
@@ -28,15 +28,7 @@ class AdminRewardsCommand(category: Command.Category, parent: Command?) : Diabot
     }
 
     override fun execute(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-
-        if (args.isEmpty()) {
-            event.replyError("must include operation")
-            return
-        }
-
-        event.replyError("Unknown command: `${args[0]}`")
+        val subcommands = children.joinToString(", ") { it.name }
+        event.replyError("Valid sub-commands are: $subcommands")
     }
-
-
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminRulesCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminRulesCommand.kt
@@ -27,8 +27,7 @@ class AdminRulesCommand(category: Command.Category, parent: Command?) : DiabotCo
     }
 
     override fun execute(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-
-        event.replyError("Unknown command: ${args[0]}")
+        val subcommands = children.joinToString(", ") { it.name }
+        event.replyError("Valid sub-commands are: $subcommands")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/AdminUsernameCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/AdminUsernameCommand.kt
@@ -27,8 +27,7 @@ class AdminUsernameCommand(category: Command.Category, parent: Command?) : Diabo
     }
 
     override fun execute(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-
-        event.replyError("Unknown command: ${args[0]}")
+        val subcommands = children.joinToString(", ") { it.name }
+        event.replyError("Valid sub-commands are: $subcommands")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelAddCommand.kt
@@ -20,21 +20,25 @@ class AdminChannelAddCommand(category: Category, parent: Command?) : DiabotComma
     override fun execute(event: CommandEvent) {
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
-        if (args.size != 1) {
-            throw IllegalArgumentException("Channel ID is required")
+        try {
+            if (args.size != 1) {
+                throw IllegalArgumentException("Channel ID is required")
+            }
+
+            if (!StringUtils.isNumeric(args[0])) {
+                throw IllegalArgumentException("Channel ID must be numeric")
+            }
+
+            val channelId = args[0]
+
+            val channel = event.jda.getTextChannelById(channelId)
+                    ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
+
+            AdminDAO.getInstance().addAdminChannel(event.guild.id, channelId)
+
+            event.reply("Added admin channel ${channel.name} (`$channelId`)")
+        } catch (ex: IllegalArgumentException) {
+            event.replyError(ex.message)
         }
-
-        if (!StringUtils.isNumeric(args[0])) {
-            throw IllegalArgumentException("Channel ID must be numeric")
-        }
-
-        val channelId = args[0]
-
-        val channel = event.jda.getTextChannelById(channelId)
-                ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
-
-        AdminDAO.getInstance().addAdminChannel(event.guild.id, channelId)
-
-        event.reply("Added admin channel ${channel.name} (`$channelId`)")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelAddCommand.kt
@@ -1,0 +1,40 @@
+package com.dongtronic.diabot.commands.admin.channels
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.AdminDAO
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import org.apache.commons.lang3.StringUtils
+import org.slf4j.LoggerFactory
+
+class AdminChannelAddCommand(category: Category, parent: Command?) : DiabotCommand(category, parent) {
+    private val logger = LoggerFactory.getLogger(AdminChannelAddCommand::class.java)
+
+    init {
+        this.name = "add"
+        this.help = "Adds a channel as an admin"
+        this.guildOnly = false
+        this.aliases = arrayOf("a")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+        if (args.size != 1) {
+            throw IllegalArgumentException("Channel ID is required")
+        }
+
+        if (!StringUtils.isNumeric(args[0])) {
+            throw IllegalArgumentException("Channel ID must be numeric")
+        }
+
+        val channelId = args[0]
+
+        val channel = event.jda.getTextChannelById(channelId)
+                ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
+
+        AdminDAO.getInstance().addAdminChannel(event.guild.id, channelId)
+
+        event.reply("Added admin channel ${channel.name} (`$channelId`)")
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelDeleteCommand.kt
@@ -1,0 +1,40 @@
+package com.dongtronic.diabot.commands.admin.channels
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.AdminDAO
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import org.apache.commons.lang3.StringUtils
+import org.slf4j.LoggerFactory
+
+class AdminChannelDeleteCommand(category: Category, parent: Command?) : DiabotCommand(category, parent) {
+    private val logger = LoggerFactory.getLogger(AdminChannelDeleteCommand::class.java)
+
+    init {
+        this.name = "delete"
+        this.help = "Removes a channel as an admin channel"
+        this.guildOnly = false
+        this.aliases = arrayOf("remove", "d", "r")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+        if (args.size != 1) {
+            throw IllegalArgumentException("Channel ID is required")
+        }
+
+        if (!StringUtils.isNumeric(args[0])) {
+            throw IllegalArgumentException("Channel ID must be numeric")
+        }
+
+        val channelId = args[0]
+
+        val channel = event.jda.getTextChannelById(channelId)
+                ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
+
+        AdminDAO.getInstance().removeAdminChannel(event.guild.id, channelId)
+
+        event.reply("Removed admin channel ${channel.name} (`$channelId`)")
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelDeleteCommand.kt
@@ -20,21 +20,25 @@ class AdminChannelDeleteCommand(category: Category, parent: Command?) : DiabotCo
     override fun execute(event: CommandEvent) {
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
-        if (args.size != 1) {
-            throw IllegalArgumentException("Channel ID is required")
+        try {
+            if (args.size != 1) {
+                throw IllegalArgumentException("Channel ID is required")
+            }
+
+            if (!StringUtils.isNumeric(args[0])) {
+                throw IllegalArgumentException("Channel ID must be numeric")
+            }
+
+            val channelId = args[0]
+
+            val channel = event.jda.getTextChannelById(channelId)
+                    ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
+
+            AdminDAO.getInstance().removeAdminChannel(event.guild.id, channelId)
+
+            event.reply("Removed admin channel ${channel.name} (`$channelId`)")
+        } catch (ex: IllegalArgumentException) {
+            event.replyError(ex.message)
         }
-
-        if (!StringUtils.isNumeric(args[0])) {
-            throw IllegalArgumentException("Channel ID must be numeric")
-        }
-
-        val channelId = args[0]
-
-        val channel = event.jda.getTextChannelById(channelId)
-                ?: throw IllegalArgumentException("Channel `$channelId` does not exist")
-
-        AdminDAO.getInstance().removeAdminChannel(event.guild.id, channelId)
-
-        event.reply("Removed admin channel ${channel.name} (`$channelId`)")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/admin/channels/AdminChannelListCommand.kt
@@ -1,0 +1,35 @@
+package com.dongtronic.diabot.commands.admin.channels
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.AdminDAO
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.api.EmbedBuilder
+import org.slf4j.LoggerFactory
+
+class AdminChannelListCommand(category: Category, parent: Command?) : DiabotCommand(category, parent) {
+    private val logger = LoggerFactory.getLogger(AdminChannelListCommand::class.java)
+
+    init {
+        this.name = "list"
+        this.help = "Lists admin channels"
+        this.guildOnly = false
+        this.aliases = arrayOf("l")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val channels = AdminDAO.getInstance().listAdminChannels(event.guild.id)
+
+        val builder = EmbedBuilder()
+
+        builder.setTitle("Admin channels")
+
+        for (channelId in channels!!) {
+            val channel = event.jda.getTextChannelById(channelId)
+
+            builder.appendDescription("**${channel!!.name}** (`${channel.id}`)\n")
+        }
+
+        event.reply(builder.build())
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutPublicCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutPublicCommand.kt
@@ -22,20 +22,30 @@ class NightscoutPublicCommand(category: Command.Category, parent: Command?) : Di
     }
 
     override fun execute(event: CommandEvent) {
-        val args = event.args.split("\\s+")
+        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
         if(args.isEmpty()) {
-            event.replyError("Please specify public status (true/false)")
+            // toggle visibility if no arguments are provided
+            val newVisibility = !NightscoutDAO.getInstance().isNightscoutPublic(event.author)
+            NightscoutDAO.getInstance().setNightscoutPublic(event.author, newVisibility)
+            reply(event, newVisibility)
+            return
         }
 
         val mode = args[0].toUpperCase()
 
         if (mode == "TRUE" || mode == "T" || mode == "YES" || mode == "Y" || mode == "ON") {
             NightscoutDAO.getInstance().setNightscoutPublic(event.author, true)
-            event.reply("Nightscout data for ${NicknameUtils.determineAuthorDisplayName(event)} set to public")
+            reply(event, true)
         } else {
             NightscoutDAO.getInstance().setNightscoutPublic(event.author, false)
-            event.reply("Nightscout data for ${NicknameUtils.determineAuthorDisplayName(event)} set to private")
+            reply(event, false)
         }
+    }
+
+    fun reply(event: CommandEvent, public: Boolean) {
+        val authorNick = NicknameUtils.determineAuthorDisplayName(event)
+        val visibility = if (public) "public" else "private"
+        event.reply("Nightscout data for $authorNick set to $visibility")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/nightscout/NightscoutSetUrlCommand.kt
@@ -47,7 +47,7 @@ class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : Di
     private fun validateNightscoutUrl(url: String): String {
         var finalUrl = url
         if (!finalUrl.contains("http://") && !finalUrl.contains("https://")) {
-            throw IllegalArgumentException("Url must contain scheme")
+            throw IllegalArgumentException("Url must contain scheme (`https://` or `http://`)")
         }
 
         if (finalUrl.endsWith("/")) {

--- a/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsCommand.kt
@@ -1,4 +1,4 @@
-package com.dongtronic.diabot.commands.misc
+package com.dongtronic.diabot.commands.rewards
 
 import com.dongtronic.diabot.commands.DiabotCommand
 import com.dongtronic.diabot.data.RewardDAO

--- a/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsCommand.kt
@@ -22,7 +22,6 @@ class RewardsCommand(category: Command.Category) : DiabotCommand(category, null)
 
     override fun execute(event: CommandEvent) {
         val subcommands = children.joinToString(", ") { it.name }
-
         event.replyError("Valid sub-commands are: $subcommands")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsCommand.kt
@@ -1,8 +1,6 @@
 package com.dongtronic.diabot.commands.rewards
 
 import com.dongtronic.diabot.commands.DiabotCommand
-import com.dongtronic.diabot.data.RewardDAO
-import com.dongtronic.diabot.util.NicknameUtils
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.slf4j.LoggerFactory
@@ -16,50 +14,15 @@ class RewardsCommand(category: Command.Category) : DiabotCommand(category, null)
         this.help = "Opt in or out of automatic role rewards"
         this.guildOnly = true
         this.aliases = arrayOf("reward", "r")
-        this.examples = arrayOf("diabot rewards optout", "diabot rewards optin")
+        this.children = arrayOf(
+                RewardsOptInCommand(category, this),
+                RewardsOptOutCommand(category, this)
+        )
     }
 
     override fun execute(event: CommandEvent) {
-        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val subcommands = children.joinToString(", ") { it.name }
 
-        if (args.isEmpty()) {
-            throw IllegalArgumentException("must include operation")
-        }
-
-        val command = args[0].toUpperCase()
-
-        try {
-            when (command) {
-                "OPTIN", "OI", "I" -> optIn(event)
-                "OPTOUT", "OU", "O" -> optOut(event)
-                else -> {
-                    throw IllegalArgumentException("unknown command $command")
-                }
-            }
-        } catch (ex: IllegalArgumentException) {
-            event.replyError(ex.message)
-        }
-    }
-
-    private fun optIn(event: CommandEvent) {
-        val guildId = event.guild.id
-
-        val user = event.author
-
-        RewardDAO.getInstance().optIn(guildId, user.id)
-
-        logger.info("User ${user.name}#${user.discriminator} (${user.id}) opted in to rewards")
-        event.reply("User ${NicknameUtils.determineDisplayName(event, user)} opted in to rewards")
-    }
-
-    private fun optOut(event: CommandEvent) {
-        val guildId = event.guild.id
-
-        val user = event.author
-
-        RewardDAO.getInstance().optOut(guildId, user.id)
-
-        logger.info("User ${user.name}#${user.discriminator} (${user.id}) opted out of rewards")
-        event.reply("User ${NicknameUtils.determineDisplayName(event, user)} opted out of rewards")
+        event.replyError("Valid sub-commands are: $subcommands")
     }
 }

--- a/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsOptInCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsOptInCommand.kt
@@ -1,0 +1,32 @@
+package com.dongtronic.diabot.commands.rewards
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.util.NicknameUtils
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import org.slf4j.LoggerFactory
+
+class RewardsOptInCommand(category: Category, parent: Command) : DiabotCommand(category, parent) {
+
+    private val logger = LoggerFactory.getLogger(RewardsOptInCommand::class.java)
+
+    init {
+        this.name = "optin"
+        this.help = "Opts in to receiving automatic role rewards"
+        this.guildOnly = true
+        this.aliases = arrayOf("oi", "i")
+        this.examples = arrayOf("optin", "oi", "i")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val guildId = event.guild.id
+
+        val user = event.author
+
+        RewardDAO.getInstance().optIn(guildId, user.id)
+
+        logger.info("User ${user.name}#${user.discriminator} (${user.id}) opted in to rewards")
+        event.reply("User ${NicknameUtils.determineDisplayName(event, user)} opted in to rewards")
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsOptOutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/commands/rewards/RewardsOptOutCommand.kt
@@ -1,0 +1,32 @@
+package com.dongtronic.diabot.commands.rewards
+
+import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.util.NicknameUtils
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import org.slf4j.LoggerFactory
+
+class RewardsOptOutCommand(category: Category, parent: Command) : DiabotCommand(category, parent) {
+
+    private val logger = LoggerFactory.getLogger(RewardsOptOutCommand::class.java)
+
+    init {
+        this.name = "optout"
+        this.help = "Opts out of receiving automatic role rewards"
+        this.guildOnly = true
+        this.aliases = arrayOf("ou", "o")
+        this.examples = arrayOf("optout", "ou", "o")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val guildId = event.guild.id
+
+        val user = event.author
+
+        RewardDAO.getInstance().optOut(guildId, user.id)
+
+        logger.info("User ${user.name}#${user.discriminator} (${user.id}) opted out of rewards")
+        event.reply("User ${NicknameUtils.determineDisplayName(event, user)} opted out of rewards")
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/data/NightscoutUserDTO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/NightscoutUserDTO.kt
@@ -4,7 +4,7 @@ import com.dongtronic.diabot.commands.nightscout.NightscoutSetDisplayCommand
 
 class NightscoutUserDTO {
     var token: String? = null
-    var displayOptions: Array<String> = NightscoutSetDisplayCommand.validOptions
+    var displayOptions: Array<String> = NightscoutSetDisplayCommand.enabledOptions
     var avatarUrl: String? = null
         set (value) {
             if (value != null) {

--- a/src/main/java/com/dongtronic/diabot/exceptions/NoCommandFoundException.kt
+++ b/src/main/java/com/dongtronic/diabot/exceptions/NoCommandFoundException.kt
@@ -1,0 +1,3 @@
+package com.dongtronic.diabot.exceptions
+
+class NoCommandFoundException(var command: String) : Exception()

--- a/src/main/java/com/dongtronic/diabot/listener/HelpListener.kt
+++ b/src/main/java/com/dongtronic/diabot/listener/HelpListener.kt
@@ -155,6 +155,10 @@ class HelpListener : Consumer<CommandEvent> {
             builder.addField("Aliases", Arrays.toString(command.aliases), false)
         }
 
+        if (isExtendedCommand && extendedCommand!!.parent != null) {
+            builder.addField("Parent command", extendedCommand.parent!!.name, false)
+        }
+
         if (command.children.isNotEmpty()) {
             builder.addField("Sub commands", Arrays.toString(command.children), false)
         }

--- a/src/main/java/com/dongtronic/diabot/listener/HelpListener.kt
+++ b/src/main/java/com/dongtronic/diabot/listener/HelpListener.kt
@@ -1,6 +1,7 @@
 package com.dongtronic.diabot.listener
 
 import com.dongtronic.diabot.commands.DiabotCommand
+import com.dongtronic.diabot.exceptions.NoCommandFoundException
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
@@ -46,45 +47,46 @@ class HelpListener : Consumer<CommandEvent> {
 
     private fun buildSpecificHelp(builder: EmbedBuilder, allCommands: List<Command>, event: CommandEvent) {
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        val commandName = args[0]
-        val subcommandName = when (args.size) {
-            2 -> args[1]
-            else -> ""
-        }
+        var currentCommand: Command? = null
+        val commandIterator = args.asList().iterator()
 
-        var found = false
+        try {
+            // Loop through arguments and search for commands matching them
+            // Stores the parent command in `currentCommand` while searching
+            while (commandIterator.hasNext()) {
+                val commandName = commandIterator.next()
 
-        for (command in allCommands) {
-            val foundCommand = getHelpCommand(command, commandName, subcommandName)
-            if (foundCommand != null) {
-                buildExtendedCommandHelp(builder, foundCommand)
-                found = true
-                break
+                currentCommand = getCommand(currentCommand, commandName, allCommands)
             }
+        } catch (exception: NoCommandFoundException) {
+            val givenCommand = exception.command
+
+            builder.setTitle("error")
+            builder.setColor(Color.red)
+
+            if (currentCommand != null) {
+                // Parent command exists, tell user the subcommand is nonexistent
+                builder.setDescription("Subcommand `$givenCommand` for command `${currentCommand.name}` does not exist")
+            } else {
+                builder.setDescription("Command `$givenCommand` does not exist")
+            }
+            return
         }
 
-        if (!found) {
-            builder.setTitle("error")
-            builder.setDescription("Command $commandName $subcommandName does not exist")
-            builder.setColor(Color.red)
-        }
+        buildExtendedCommandHelp(builder, currentCommand!!)
     }
 
-    private fun getHelpCommand(command: Command, commandName: String, subcommandName: String): Command? {
+    private fun getCommand(currentCommand: Command?, commandName: String, allCommands: List<Command>): Command {
+        // if parent command exists then search through the subcommands for it
+        val commands = currentCommand?.children?.asList() ?: allCommands
 
-        if(command.isCommandFor(commandName) && subcommandName.isEmpty()) {
-            return command
-        }
-
-
-        for (subCommand in command.children) {
-            val foundCommand = getHelpCommand(subCommand, subcommandName, "")
-            if (foundCommand != null) {
-                return foundCommand
+        for (command in commands) {
+            if (command.isCommandFor(commandName)) {
+                return command
             }
         }
 
-        return null
+        throw NoCommandFoundException(commandName)
     }
 
     private fun buildCategoryHelp(builder: EmbedBuilder, category: Map.Entry<String, ArrayList<Command>>) {


### PR DESCRIPTION
This PR improves several areas involving Diabot commands

- Uses the proper default options when initializing a new `NightscoutUserDTO` instance (#75) 
- Converted `admin channels` and `rewards` commands to use JDA subcommands (#74)
- Improvements to `help` command (#50)
	- Rewrote the searching and matching functions for commands
		- Allows help for subcommands of subcommands (and so on..) to be found (`diabot help admin channels list`)
		- Fixes a bug where subcommands could be matched to the incorrect parent command (`diabot help na list` would give help for `diabot info list` instead)
	- Shows parent command name in extended help if help for a subcommand is being displaying
- Returns a list of valid subcommands by default for commands that only expect a subcommand to be used
	- At the moment, most commands expecting subcommands return `Unknown command` or `must include operation` if no arguments are provided
- Included an example of URL schemes in the error message of `diabot ns set` (partially #59)
- Improved parsing of arguments with `diabot ns public` (partially #59)
	- If no arguments are given then the user's nightscout privacy will be toggled between public and private