### PR TITLE
Remove /api/v1 when setting Nightscout url

### DIFF
--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetUrlCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetUrlCommand.kt
@@ -1,7 +1,7 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiabotCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiabotCommand
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
@@ -52,6 +52,10 @@ class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : Di
 
         if (finalUrl.endsWith("/")) {
             finalUrl = finalUrl.trimEnd('/')
+        }
+
+        if (finalUrl.endsWith("/api/v1")) {
+            finalUrl = finalUrl.removeSuffix("/api/v1")
         }
 
         return finalUrl


### PR DESCRIPTION
xDrip+ requires the nightscout URL to have `/api/v1/` at the end when setting up nightscout syncing in the app. This may confuse some people who are trying to link Diabot to their nightscout as it will accept a URL with this API path but will return an error when running the nightscout command. To solve this, I've made it so `/api/v1` will be trimmed from the end of the URL specified