### PR TITLE
Merge pull request #83 from reddit-diabetes/http-components

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile 'org.jsoup:jsoup:1.11.3'
 
     // Apache Commons
-    compile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.11'
     compile 'org.apache.commons:commons-lang3:3.8.1'
     compile 'commons-configuration:commons-configuration:1.6'
 

--- a/src/main/java/com/dongtronic/diabot/logic/fun/Awyisser.kt
+++ b/src/main/java/com/dongtronic/diabot/logic/fun/Awyisser.kt
@@ -19,6 +19,7 @@ object Awyisser {
 
         //Add any parameter if u want to send it with Post req.
         request.addParameter("phrase", input)
+        request.setUri(url)
 
         val response = client.execute(request.build())
 

--- a/src/main/java/com/dongtronic/diabot/logic/fun/Awyisser.kt
+++ b/src/main/java/com/dongtronic/diabot/logic/fun/Awyisser.kt
@@ -2,8 +2,9 @@ package com.dongtronic.diabot.logic.`fun`
 
 import com.dongtronic.diabot.exceptions.RequestStatusException
 import com.google.gson.JsonParser
-import org.apache.commons.httpclient.HttpClient
-import org.apache.commons.httpclient.methods.PostMethod
+import org.apache.http.client.methods.RequestBuilder
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.util.EntityUtils
 
 object Awyisser {
     const val url = "http://awyisser.com/api/generator"
@@ -13,19 +14,19 @@ object Awyisser {
      * @return URL to the generated image
      */
     fun generate(input: String): String {
-        val client = HttpClient()
-        val method = PostMethod(url)
+        val client = HttpClients.createDefault()
+        val request = RequestBuilder.post()
 
         //Add any parameter if u want to send it with Post req.
-        method.addParameter("phrase", input)
+        request.addParameter("phrase", input)
 
-        val statusCode = client.executeMethod(method)
+        val response = client.execute(request.build())
 
-        if (statusCode == -1) {
+        if (response.statusLine.statusCode == -1) {
             throw RequestStatusException(-1)
         }
 
-        val json = method.responseBodyAsString
+        val json = EntityUtils.toString(response.entity)
 
         val jsonObject = JsonParser().parse(json).asJsonObject
         return jsonObject.get("link").asString

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/ShutdownCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/ShutdownCommand.kt
@@ -3,7 +3,6 @@ package com.dongtronic.diabot.platforms.discord.commands.admin
 import com.dongtronic.diabot.platforms.discord.commands.DiabotCommand
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import net.dv8tion.jda.api.Permission
 import org.slf4j.LoggerFactory
 
 /**
@@ -17,7 +16,6 @@ class ShutdownCommand(category: Command.Category) : DiabotCommand(category, null
         this.guildOnly = false
         this.ownerCommand = false
         this.aliases = arrayOf("heckoff", "fuckoff", "removethyself", "remove")
-        this.userPermissions = arrayOf(Permission.ADMINISTRATOR)
         this.hidden = true
     }
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/AwyissCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/AwyissCommand.kt
@@ -2,14 +2,10 @@ package com.dongtronic.diabot.platforms.discord.commands.misc
 
 import com.dongtronic.diabot.logic.`fun`.Awyisser
 import com.dongtronic.diabot.platforms.discord.commands.DiabotCommand
-import com.google.gson.JsonParser
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
-import org.apache.commons.httpclient.HttpClient
-import org.apache.commons.httpclient.methods.PostMethod
-
-import java.awt.*
+import java.awt.Color
 
 class AwyissCommand(category: Command.Category) : DiabotCommand(category, null) {
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
@@ -76,6 +76,9 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
         } catch (ex: InsufficientPermissionException) {
             logger.info("Couldn't reply with nightscout data due to missing permission: ${ex.permission}")
             event.replyError("Couldn't perform requested action due to missing permission: `${ex.permission}`")
+        } catch (ex: UnknownHostException) {
+            event.reactError()
+            logger.info("No host found: ${ex.message}")
         } catch (ex: Exception) {
             event.reactError()
             logger.warn("Unexpected error: " + ex.message)
@@ -107,9 +110,6 @@ class NightscoutCommand(category: Command.Category) : DiabotCommand(category, nu
             }
 
             return
-        } catch (ex: UnknownHostException) {
-            event.reactError()
-            logger.info("No host found: ${ex.message}")
         }
 
         val shortReply = NightscoutDAO.getInstance().listShortChannels(event.guild.id).contains(event.channel.id) ||

--- a/src/main/java/com/dongtronic/diabot/util/LimitedSystemDnsResolver.kt
+++ b/src/main/java/com/dongtronic/diabot/util/LimitedSystemDnsResolver.kt
@@ -1,0 +1,31 @@
+package com.dongtronic.diabot.util
+
+import org.apache.http.impl.conn.SystemDefaultDnsResolver
+import java.net.InetAddress
+
+class LimitedSystemDnsResolver: SystemDefaultDnsResolver() {
+    /**
+     * Resolves IP addresses for a host, limiting to the amount in the `limit` parameter
+     */
+    fun resolve(host: String?, limit: Int): Array<InetAddress> {
+        return super.resolve(host).take(limit).toTypedArray()
+    }
+
+    /**
+     * Resolves IP addresses for a host, limiting to the first 2 IP addresses
+     */
+    override fun resolve(host: String?): Array<InetAddress> {
+        return resolve(host, 2)
+    }
+
+    companion object {
+        private var instance: LimitedSystemDnsResolver? = null
+
+        fun getInstance(): LimitedSystemDnsResolver {
+            if (instance == null) {
+                instance = LimitedSystemDnsResolver()
+            }
+            return instance as LimitedSystemDnsResolver
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/util/LimitedSystemDnsResolver.kt
+++ b/src/main/java/com/dongtronic/diabot/util/LimitedSystemDnsResolver.kt
@@ -3,29 +3,18 @@ package com.dongtronic.diabot.util
 import org.apache.http.impl.conn.SystemDefaultDnsResolver
 import java.net.InetAddress
 
-class LimitedSystemDnsResolver: SystemDefaultDnsResolver() {
+class LimitedSystemDnsResolver(private val limit: Int = 2) : SystemDefaultDnsResolver() {
     /**
-     * Resolves IP addresses for a host, limiting to the amount in the `limit` parameter
+     * Resolves IP addresses for a host, limiting to the amount in the `max` parameter
      */
-    fun resolve(host: String?, limit: Int): Array<InetAddress> {
-        return super.resolve(host).take(limit).toTypedArray()
+    fun resolve(host: String?, max: Int): Array<InetAddress> {
+        return super.resolve(host).take(max).toTypedArray()
     }
 
     /**
-     * Resolves IP addresses for a host, limiting to the first 2 IP addresses
+     * Resolves a limited number of IP addresses for a host
      */
     override fun resolve(host: String?): Array<InetAddress> {
-        return resolve(host, 2)
-    }
-
-    companion object {
-        private var instance: LimitedSystemDnsResolver? = null
-
-        fun getInstance(): LimitedSystemDnsResolver {
-            if (instance == null) {
-                instance = LimitedSystemDnsResolver()
-            }
-            return instance as LimitedSystemDnsResolver
-        }
+        return resolve(host, this.limit)
     }
 }


### PR DESCRIPTION
HttpClient in Commons is deprecated and was no longer being developed. [The documentation for it recommends switching to HttpComponents](https://hc.apache.org/httpclient-3.x/) which is what I've done in this PR.

The main reason why I felt this was necessary is because the Commons HttpClient library does not properly support DNS round robin. HttpClient will connect to the first A record and give up which may cause issues for users who host on servers that rely on this.

In addition to this, I set the connection timeouts for Nightscout requests to 8 seconds and limited the maximum number of IPs to attempt down to two. (part of the round-robin DNS support) 

Lastly, I made a couple small changes:
- Reverted the project JDK name back to 1.8
- Removed the need for users to have the `ADMINISTRATOR` discord permission for the shutdown command (authentication is done through the `superusers` environment variable already)