### PR TITLE
add bs as nightscout alias

### DIFF
--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
@@ -51,7 +51,7 @@ class NightscoutCommand(category: Command.Category) : DiscordCommand(category, n
         this.help = "Get the most recent info from any Nightscout site"
         this.arguments = "Partial Nightscout url (part before .herokuapp.com)"
         this.guildOnly = false
-        this.aliases = arrayOf("ns", "bg")
+        this.aliases = arrayOf("ns", "bg", "bs")
         this.examples = arrayOf("diabot nightscout casscout", "diabot ns", "diabot ns set https://casscout.herokuapp.com", "diabot ns public false")
         this.children = arrayOf(
                 NightscoutSetUrlCommand(category, this),


### PR DESCRIPTION
popular request in chat for a "blood sugar" option when requesting nightscout data. 
To be clear I did not formally test this integration because it is so straightforward. If you'd like me to I will. "bs" is not an alias for any other command which is why I'm confident it works. 