### PR TITLE
Quoting feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,12 +34,16 @@ dependencies {
 
     // Database
     compile 'redis.clients:jedis:3.3.0'
+    compile 'org.mongodb:mongodb-driver-reactivestreams:4.0.5'
+    compile 'org.litote.kmongo:kmongo-async:4.0.3'
 
     // Testing
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     // Misc
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    compile 'io.projectreactor:reactor-core:3.3.8.RELEASE'
+    compile 'io.projectreactor.kotlin:reactor-kotlin-extensions:1.0.2.RELEASE'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.2.51'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
 }
 
 group 'com.dongtronic'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/src/main/java/com/dongtronic/diabot/Main.kt
+++ b/src/main/java/com/dongtronic/diabot/Main.kt
@@ -10,6 +10,7 @@ import com.dongtronic.diabot.platforms.discord.commands.info.InfoCommand
 import com.dongtronic.diabot.platforms.discord.commands.misc.*
 import com.dongtronic.diabot.platforms.discord.commands.nightscout.NightscoutAdminCommand
 import com.dongtronic.diabot.platforms.discord.commands.nightscout.NightscoutCommand
+import com.dongtronic.diabot.platforms.discord.commands.quote.QuoteCommand
 import com.dongtronic.diabot.platforms.discord.commands.rewards.RewardsCommand
 import com.dongtronic.diabot.platforms.discord.listeners.*
 import com.jagrosh.jdautilities.command.Command.Category
@@ -92,6 +93,7 @@ object Main {
                 AwyissCommand(funCategory),
                 DiacastCommand(funCategory),
                 OwnerCommand(funCategory),
+                QuoteCommand(funCategory),
 
                 // Admin
                 AdminCommand(adminCategory),

--- a/src/main/java/com/dongtronic/diabot/Main.kt
+++ b/src/main/java/com/dongtronic/diabot/Main.kt
@@ -118,7 +118,8 @@ object Main {
                         ConversionListener(),
                         RewardListener(),
                         UsernameEnforcementListener(),
-                        OhNoListener()
+                        OhNoListener(),
+                        QuoteListener()
                 )
                 // start it up!
                 .build()

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -18,10 +18,8 @@ import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
-import redis.clients.jedis.Jedis
 
 class QuoteDAO private constructor() {
-    private var jedis: Jedis? = null
     private var collection: MongoCollection<QuoteDTO>? = null
     private var quoteIndexes: MongoCollection<QuoteIndexDTO>? = null
     private val logger = LoggerFactory.getLogger(QuoteDAO::class.java)
@@ -29,7 +27,6 @@ class QuoteDAO private constructor() {
     val maxQuotes = System.getenv().getOrDefault("QUOTE_MAX", "5000").toIntOrNull() ?: 5000
 
     init {
-        jedis = Jedis(System.getenv("REDIS_URL"))
         collection = MongoDB.getInstance().database.getCollection("quotes", QuoteDTO::class.java)
         quoteIndexes = MongoDB.getInstance().database.getCollection("quote-numbers", QuoteIndexDTO::class.java)
     }

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -59,7 +59,7 @@ class QuoteDAO private constructor() {
 
             collection!!.insertOne(quoteDTO).toMono().map {
                 if (!it.wasAcknowledged())
-                    throw IllegalStateException("Could not insert")
+                    throw IllegalStateException("Could not insert quote")
 
                 quoteDTO
             }

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -28,7 +28,7 @@ class QuoteDAO private constructor() {
 
     init {
         collection = MongoDB.getInstance().database.getCollection("quotes", QuoteDTO::class.java)
-        quoteIndexes = MongoDB.getInstance().database.getCollection("quote-numbers", QuoteIndexDTO::class.java)
+        quoteIndexes = MongoDB.getInstance().database.getCollection("quote-index", QuoteIndexDTO::class.java)
     }
 
     /**

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -1,0 +1,244 @@
+package com.dongtronic.diabot.data
+
+import com.dongtronic.diabot.util.RedisKeyFormats
+import org.slf4j.LoggerFactory
+import redis.clients.jedis.Jedis
+
+class QuoteDAO private constructor() {
+    private var jedis: Jedis? = null
+    private val logger = LoggerFactory.getLogger(QuoteDAO::class.java)
+
+    init {
+        jedis = Jedis(System.getenv("REDIS_URL"))
+    }
+
+    /**
+     * Gets a [QuoteDTO] from a quote ID
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     * @return [QuoteDTO] instance, null if quote not found
+     */
+    fun getQuote(guildId: String, quoteId: String): QuoteDTO? {
+        val author = getQuoteAuthor(guildId, quoteId) ?: return null
+        val message = getQuoteMessage(guildId, quoteId) ?: return null
+        val timestamp = getQuoteTime(guildId, quoteId) ?: return null
+
+        return QuoteDTO(id = quoteId, author = author, message = message, time = timestamp)
+    }
+
+    /**
+     * Creates a [QuoteDTO] instance from the included parameters and inserts it into the database.
+     *
+     * @param guildId guild ID
+     * @param author the quote's author
+     * @param message the quote message
+     * @param timestamp quote creation in unix time
+     * @return the created [QuoteDTO] instance if successful, null otherwise
+     */
+    fun addQuote(guildId: String, author: String, message: String, timestamp: Long): QuoteDTO? {
+        // cancel if the new quote id cannot be found
+        val id = incrementId(guildId) ?: return null
+        val quoteDTO = QuoteDTO(id = id.toString(), author = author, message = message, time = timestamp)
+
+        setQuote(guildId, quoteDTO)
+        return getQuote(guildId, id.toString())
+    }
+
+    /**
+     * Places the data of a [QuoteDTO] instance into redis
+     *
+     * @param guildId guild ID
+     * @param quoteDTO quote DTO
+     * @param store whether to store this quote's ID in the quote list under a new entry
+     */
+    fun setQuote(guildId: String, quoteDTO: QuoteDTO, store: Boolean = true) {
+        val id = quoteDTO.id
+
+        setQuoteAuthor(guildId, id, quoteDTO.author)
+        setQuoteMessage(guildId, id, quoteDTO.message)
+        setQuoteTime(guildId, id, quoteDTO.time)
+        if (store) {
+            storeQuote(guildId, id, delete = false)
+        }
+    }
+
+    /**
+     * Deletes a quote from redis
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     */
+    fun deleteQuote(guildId: String, quoteId: String) {
+        setQuoteAuthor(guildId, quoteId, "")
+        setQuoteMessage(guildId, quoteId, "")
+        setQuoteTime(guildId, quoteId, -1)
+        storeQuote(guildId, quoteId, delete = true)
+    }
+
+    /**
+     * Gets the quote's author
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     * @return the author, null if not found
+     */
+    fun getQuoteAuthor(guildId: String, quoteId: String): String? {
+        val redisKey = RedisKeyFormats.quoteAuthor
+                .replace("{{guildid}}", guildId)
+                .replace("{{quoteid}}", quoteId)
+
+        return jedis!!.get(redisKey)
+    }
+
+    /**
+     * Sets the author for a quote
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     * @param author the quote's author. set blank to delete
+     */
+    private fun setQuoteAuthor(guildId: String, quoteId: String, author: String) {
+        val redisKey = RedisKeyFormats.quoteAuthor
+                .replace("{{guildid}}", guildId)
+                .replace("{{quoteid}}", quoteId)
+
+        if (author.isBlank()) {
+            jedis!!.del(redisKey)
+        } else {
+            jedis!!.set(redisKey, author)
+        }
+    }
+
+    /**
+     * Gets a quote's message text
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     * @return message text, null if not found
+     */
+    fun getQuoteMessage(guildId: String, quoteId: String): String? {
+        val redisKey = RedisKeyFormats.quoteMessage
+                .replace("{{guildid}}", guildId)
+                .replace("{{quoteid}}", quoteId)
+
+        return jedis!!.get(redisKey)
+    }
+
+    /**
+     * Sets the message text for a quote
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     * @param message the quote's message content. set blank to delete
+     */
+    private fun setQuoteMessage(guildId: String, quoteId: String, message: String) {
+        val redisKey = RedisKeyFormats.quoteMessage
+                .replace("{{guildid}}", guildId)
+                .replace("{{quoteid}}", quoteId)
+
+        if (message.isBlank()) {
+            jedis!!.del(redisKey)
+        } else {
+            jedis!!.set(redisKey, message)
+        }
+    }
+
+    /**
+     * Gets the time when the quote was created
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     * @return creation time in unix time, null if not found
+     */
+    fun getQuoteTime(guildId: String, quoteId: String): Long? {
+        val redisKey = RedisKeyFormats.quoteTime
+                .replace("{{guildid}}", guildId)
+                .replace("{{quoteid}}", quoteId)
+
+        return jedis!!.get(redisKey)?.toLongOrNull()
+    }
+
+    /**
+     * Sets the time when the quote was created.
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     * @param time creation time in unix time. set to -1L to delete
+     */
+    private fun setQuoteTime(guildId: String, quoteId: String, time: Long) {
+        val redisKey = RedisKeyFormats.quoteTime
+                .replace("{{guildid}}", guildId)
+                .replace("{{quoteid}}", quoteId)
+
+        if (time == -1L) {
+            jedis!!.del(redisKey)
+        } else {
+            jedis!!.set(redisKey, time.toString())
+        }
+    }
+
+    /**
+     * Creates a list of all the quote IDs defined under a guild
+     *
+     * @param guildId guild ID
+     * @return all quote IDs for the specified guild, null if not found
+     */
+    fun listQuoteIds(guildId: String): Collection<String>? {
+        val redisKey = RedisKeyFormats.quoteIds.replace("{{guildid}}", guildId)
+        val length = quoteAmount(guildId)?.minus(1) ?: 0
+
+        return jedis!!.lrange(redisKey, 0, length)
+    }
+
+    /**
+     * Gets the amount of quotes in this guild
+     *
+     * @param guildId guild ID
+     * @return number of quotes for the specified guild, null if not found
+     */
+    fun quoteAmount(guildId: String): Long? {
+        val redisKey = RedisKeyFormats.quoteIds.replace("{{guildid}}", guildId)
+        return jedis!!.llen(redisKey)
+    }
+
+    /**
+     * Increments the guild-wide quote ID index by one and returns the index after incrementing
+     *
+     * @param guildId guild ID
+     * @return the ID index of the specified guild after incrementing
+     */
+    fun incrementId(guildId: String): Long? {
+        val redisKey = RedisKeyFormats.quoteIndex.replace("{{guildid}}", guildId)
+
+        return jedis!!.incr(redisKey)
+    }
+
+    /**
+     * Stores (or deletes) the quote ID inside the quote list key
+     *
+     * @param guildId guild ID
+     * @param quoteId quote ID
+     * @param delete whether to delete the quote ID from the list
+     */
+    fun storeQuote(guildId: String, quoteId: String, delete: Boolean = false) {
+        val redisKey = RedisKeyFormats.quoteIds.replace("{{guildid}}", guildId)
+
+        if (delete) {
+            jedis!!.lrem(redisKey, 0, quoteId)
+        } else {
+            jedis!!.lpush(redisKey, quoteId)
+        }
+    }
+
+    companion object {
+        private var instance: QuoteDAO? = null
+
+        fun getInstance(): QuoteDAO {
+            if (instance == null) {
+                instance = QuoteDAO()
+            }
+            return instance as QuoteDAO
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -264,6 +264,17 @@ class QuoteDAO private constructor() {
     }
 
     /**
+     * Creates a list of quotes defined under a guild matching the given predicate
+     *
+     * @param guildId String
+     * @param predicate predicate
+     * @return list of [QuoteDTO]s matching the predicate
+     */
+    fun listQuotesByPredicate(guildId: String, predicate: (QuoteDTO) -> Boolean): List<QuoteDTO>? {
+        return listQuoteIds(guildId)?.mapNotNull { getQuote(guildId, it) }?.filter(predicate)
+    }
+
+    /**
      * Gets the amount of quotes in this guild
      *
      * @param guildId guild ID

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -128,7 +128,7 @@ class QuoteDAO private constructor() {
                 .returnDocument(ReturnDocument.AFTER)
 
         return quoteIndexes!!.findOneAndUpdate(QuoteIndexDTO::guildId eq guildId,
-                Updates.inc("quoteIndex", 1), options)
+                Updates.inc("quoteIndex", 1L), options)
                 .toMono()
                 .subscribeOn(scheduler)
                 .map { it.quoteIndex }

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDTO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDTO.kt
@@ -1,19 +1,33 @@
 package com.dongtronic.diabot.data
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect
 
 /**
- * @property id the quote's ID
+ * @property quoteId the quote's ID
+ * @property guildId the guild in which this quote belongs to
  * @property author the quote's author
  * @property authorId the author's user ID
  * @property message the quote message
  * @property messageId the quote's message ID
  * @property time quote creation in unix time
  */
+@JsonAutoDetect
 data class QuoteDTO(
-        val id: String = "",
+        val quoteId: Long? = null,
+        val guildId: Long,
         val author: String,
         val authorId: Long = 0,
         val message: String,
         val messageId: Long,
         val time: Long = System.currentTimeMillis() / 1000
+)
+
+/**
+ * @property guildId the guild ID
+ * @property quoteIndex this guild's current quote index
+ */
+@JsonAutoDetect
+data class QuoteIndexDTO(
+        val guildId: Long,
+        val quoteIndex: Long = 1
 )

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDTO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDTO.kt
@@ -1,0 +1,10 @@
+package com.dongtronic.diabot.data
+
+
+data class QuoteDTO(
+        val id: String,
+        val author: String,
+        val authorId: Long? = null,
+        val message: String,
+        val time: Long = System.currentTimeMillis() / 1000
+)

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDTO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDTO.kt
@@ -1,10 +1,19 @@
 package com.dongtronic.diabot.data
 
 
+/**
+ * @property id the quote's ID
+ * @property author the quote's author
+ * @property authorId the author's user ID
+ * @property message the quote message
+ * @property messageId the quote's message ID
+ * @property time quote creation in unix time
+ */
 data class QuoteDTO(
-        val id: String,
+        val id: String = "",
         val author: String,
-        val authorId: Long? = null,
+        val authorId: Long = 0,
         val message: String,
+        val messageId: Long,
         val time: Long = System.currentTimeMillis() / 1000
 )

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDTO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDTO.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect
 /**
  * @property quoteId the quote's ID
  * @property guildId the guild in which this quote belongs to
+ * @property channelId the channel which this quote is located under
  * @property author the quote's author
  * @property authorId the author's user ID
  * @property message the quote message
@@ -15,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect
 data class QuoteDTO(
         val quoteId: Long? = null,
         val guildId: Long,
+        val channelId: Long,
         val author: String,
         val authorId: Long = 0,
         val message: String,

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -30,14 +30,17 @@ class QuoteAddCommand(category: Category, parent: Command) : DiscordCommand(cate
         val author = match.groups["author"]!!.value.trim()
         val message = match.groups["message"]!!.value.trim()
 
-        val quote = QuoteDAO.getInstance().addQuote(
-                guildId = event.guild.id,
-                quote = QuoteDTO(author = author, message = message, messageId = event.message.idLong)
-        )
-        if (quote != null) {
-            event.replySuccess("New quote added by ${event.author.name} as #${quote.id}")
-        } else {
-            event.replyError("Could not add quote")
-        }
+        val quoteDto = QuoteDTO(guildId = event.guild.idLong,
+                author = author,
+                message = message,
+                messageId = event.message.idLong)
+
+        QuoteDAO.getInstance().addQuote(quoteDto).subscribe(
+                {
+                    event.replySuccess("New quote added by ${event.author.name} as #${it.quoteId}")
+                },
+                {
+                    event.replyError("Could not add quote: ${it.message}")
+                })
     }
 }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -42,6 +42,7 @@ class QuoteAddCommand(category: Category, parent: Command) : DiscordCommand(cate
                 },
                 {
                     event.replyError("Could not add quote: ${it.message}")
+                    logger.warn("Unexpected error: " + it::class.simpleName + " - " + it.message)
                 })
     }
 }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -38,7 +38,7 @@ class QuoteAddCommand(category: Category, parent: Command) : DiscordCommand(cate
 
         QuoteDAO.getInstance().addQuote(quoteDto).subscribe(
                 {
-                    event.replySuccess("New quote added by ${event.author.name} as #${it.quoteId}")
+                    event.replySuccess("New quote added by ${event.member.effectiveName} as #${it.quoteId}")
                 },
                 {
                     event.replyError("Could not add quote: ${it.message}")

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -1,0 +1,41 @@
+package com.dongtronic.diabot.platforms.discord.commands.quote
+
+import com.dongtronic.diabot.data.QuoteDAO
+import com.dongtronic.diabot.data.QuoteDTO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import org.slf4j.LoggerFactory
+
+class QuoteAddCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
+    private val quoteRegex = Regex("\"(?<message>[\\s\\S]*)\" ?- ?(?<author>.*[^\\s])")
+    private val logger = LoggerFactory.getLogger(QuoteAddCommand::class.java)
+
+    init {
+        this.name = "add"
+        this.help = "Creates new quotes"
+        this.guildOnly = true
+        this.aliases = arrayOf("a")
+        this.examples = arrayOf(this.parent!!.name + " add \"this is a quote added manually\" - gar")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val match = quoteRegex.matchEntire(event.args)
+        if (match == null) {
+            event.replyError("Could not parse quote. Please make sure you are using the correct format for this command")
+            return
+        }
+        val author = match.groups["author"]!!.value.trim()
+        val message = match.groups["message"]!!.value.trim()
+
+        val quote = QuoteDAO.getInstance().addQuote(
+                guildId = event.guild.id,
+                quote = QuoteDTO(author = author, message = message, messageId = event.message.idLong)
+        )
+        if (quote != null) {
+            event.replySuccess("New quote added by ${event.author.name} as #${quote.id}")
+        } else {
+            event.replyError("Could not add quote")
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -20,6 +20,8 @@ class QuoteAddCommand(category: Category, parent: Command) : DiscordCommand(cate
     }
 
     override fun execute(event: CommandEvent) {
+        if (!QuoteDAO.checkRestrictions(event.textChannel, warnDisabledGuild = true)) return
+
         val match = quoteRegex.matchEntire(event.args)
         if (match == null) {
             event.replyError("Could not parse quote. Please make sure you are using the correct format for this command")

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -31,6 +31,7 @@ class QuoteAddCommand(category: Category, parent: Command) : DiscordCommand(cate
         val message = match.groups["message"]!!.value.trim()
 
         val quoteDto = QuoteDTO(guildId = event.guild.idLong,
+                channelId = event.channel.idLong,
                 author = author,
                 message = message,
                 messageId = event.message.idLong)

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -1,0 +1,131 @@
+package com.dongtronic.diabot.platforms.discord.commands.quote
+
+import com.dongtronic.diabot.data.QuoteDAO
+import com.dongtronic.diabot.data.QuoteDTO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.slf4j.LoggerFactory
+import java.time.Instant
+
+class QuoteCommand(category: Category) : DiscordCommand(category, null) {
+    private val mentionsRegex = Regex("<@(?<uid>\\d+)>")
+    private val logger = LoggerFactory.getLogger(QuoteCommand::class.java)
+
+    init {
+        this.name = "quote"
+        this.help = "Gets saved quotes"
+        this.guildOnly = true
+        this.aliases = arrayOf("q")
+        this.examples = arrayOf("diabot quote", "diabot quote 1337", "diabot quote @Cas")
+        this.children = arrayOf(
+                QuoteAddCommand(category, this),
+                QuoteDeleteCommand(category, this),
+                QuoteEditCommand(category, this))
+    }
+
+    override fun execute(event: CommandEvent) {
+        val mentions = mentionsRegex.find(event.args)
+        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+        val quote = when {
+            mentions != null -> {
+                val name = resolveNameById(mentions.groups["uid"]!!.value, event)
+                getRandomQuote(event.guild.id) { it.author.equals(name, ignoreCase = true) }
+            }
+            args.isNotEmpty() -> {
+                if (args.all { it.toLongOrNull() != null }) {
+                    // may be a quote id
+                    QuoteDAO.getInstance().getQuote(event.guild.id, args[0])
+                } else {
+                    // may be a username
+                    val joined = args.joinToString(" ")
+                    getRandomQuote(event.guild.id) { it.author.equals(joined, ignoreCase = true) }
+                }
+            }
+            else -> getRandomQuote(event.guild.id)
+        }
+
+        if (quote != null) {
+            val messageStripped = stripMentions(quote.message, event)
+            event.reply(createEmbed(quote.copy(message = messageStripped)))
+        } else {
+            event.replyError("Could not find any quote")
+        }
+    }
+
+    /**
+     * Creates an embed from a [QuoteDTO]
+     *
+     * @param quoteDTO the quote to generate an embed from
+     * @return an embed containing the quote's details
+     */
+    private fun createEmbed(quoteDTO: QuoteDTO): MessageEmbed {
+        val builder = EmbedBuilder()
+        builder.setAuthor("#" + quoteDTO.id)
+
+        val descriptionBuilder = StringBuilder(quoteDTO.message)
+        descriptionBuilder.append("\n")
+        descriptionBuilder.append("- ").append(quoteDTO.author)
+
+        builder.setDescription(descriptionBuilder.toString())
+
+        builder.setTimestamp(Instant.ofEpochSecond(quoteDTO.time))
+        return builder.build()
+    }
+
+    /**
+     * Gets a random quote fitting the given predicate, if any.
+     *
+     * @param guildId the guild ID to look under
+     * @param predicate filter for certain quotes
+     * @return a random [QuoteDTO], or null if none found
+     */
+    private fun getRandomQuote(guildId: String, predicate: (QuoteDTO) -> Boolean = { true }): QuoteDTO? {
+        val quotes = QuoteDAO.getInstance().listQuotesByPredicate(guildId, predicate)
+        if (quotes.isNullOrEmpty())
+            return null
+        return quotes.random()
+    }
+
+    /**
+     * Strips a message of mentions for users inside the guild.
+     * Mentions which reference a user who is not in the guild will not be stripped.
+     *
+     * @param message the message to strip of mentions
+     * @param event command event
+     * @return stripped message
+     */
+    private fun stripMentions(message: String, event: CommandEvent): String {
+        var strippedMessage = message
+        val matches = mentionsRegex.findAll(message)
+        // using `toMap` to remove duplicate mentions
+        val uidMap = matches.mapNotNull {
+            val uid = it.groups["uid"]?.value ?: return@mapNotNull null
+            it.value to uid
+        }.toMap()
+
+        // replace the ids with their real names
+        uidMap.mapValues { resolveNameById(it.value, event) }
+                .forEach { (match, id) ->
+                    if (id.isBlank())
+                        return@forEach
+
+                    strippedMessage = strippedMessage.replace(match, "@$id")
+                }
+
+        return strippedMessage
+    }
+
+    /**
+     * Gets a nickname or account name by a Discord account ID if it is in the same guild
+     *
+     * @param id Discord account ID
+     * @param event command event
+     * @return account name if the id was found in the guild, otherwise blank
+     */
+    private fun resolveNameById(id: String, event: CommandEvent): String {
+        return event.guild.getMemberById(id)?.effectiveName ?: ""
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -32,13 +32,12 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
     override fun execute(event: CommandEvent) {
         if (!QuoteDAO.checkRestrictions(event.textChannel, warnDisabledGuild = true, checkQuoteLimit = false)) return
 
-        val mentions = mentionsRegex.find(event.args)
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
         val quote = when {
-            mentions != null -> {
-                val name = resolveNameById(mentions.groups["uid"]!!.value, event)
-                getRandomQuote(event.guild.idLong, QuoteDTO::author eq name)
+            event.message.mentionedMembers.isNotEmpty() -> {
+                val member = event.message.mentionedMembers.first()
+                getRandomQuote(event.guild.idLong, QuoteDTO::authorId eq member.idLong)
             }
             args.isNotEmpty() -> {
                 if (args.all { it.toLongOrNull() != null }) {

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -78,7 +78,9 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
         descriptionBuilder.append("\n")
         descriptionBuilder.append("- ").append(quoteDTO.author)
 
-        if (quoteDTO.channelId != 0L) {
+        if (quoteDTO.guildId != 0L
+                && quoteDTO.channelId != 0L
+                && quoteDTO.messageId != 0L) {
             val jumpLink = discordMessageLink.replace("{{guild}}", quoteDTO.guildId.toString())
                     .replace("{{channel}}", quoteDTO.channelId.toString())
                     .replace("{{message}}", quoteDTO.messageId.toString())

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -58,6 +58,9 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
             event.reply(createEmbed(it.copy(message = messageStripped)))
         }, {
             event.replyError("Could not find any quote")
+            if (it !is NoSuchElementException) {
+                logger.warn("Unexpected error: " + it::class.simpleName + " - " + it.message)
+            }
         })
     }
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -14,6 +14,7 @@ import java.time.Instant
 
 class QuoteCommand(category: Category) : DiscordCommand(category, null) {
     private val mentionsRegex = Regex("<@(?<uid>\\d+)>")
+    private val discordMessageLink = "https://discordapp.com/channels/{{guild}}/{{channel}}/{{message}}"
     private val logger = LoggerFactory.getLogger(QuoteCommand::class.java)
 
     init {
@@ -73,6 +74,14 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
         val descriptionBuilder = StringBuilder(quoteDTO.message)
         descriptionBuilder.append("\n")
         descriptionBuilder.append("- ").append(quoteDTO.author)
+
+        if (quoteDTO.channelId != 0L) {
+            val jumpLink = discordMessageLink.replace("{{guild}}", quoteDTO.guildId.toString())
+                    .replace("{{channel}}", quoteDTO.channelId.toString())
+                    .replace("{{message}}", quoteDTO.messageId.toString())
+            val jumpText = "[(Jump)]($jumpLink)"
+            descriptionBuilder.append(" ").append(jumpText)
+        }
 
         builder.setDescription(descriptionBuilder.toString())
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -26,6 +26,8 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
     }
 
     override fun execute(event: CommandEvent) {
+        if (!QuoteDAO.checkRestrictions(event.textChannel, warnDisabledGuild = true, checkQuoteLimit = false)) return
+
         val mentions = mentionsRegex.find(event.args)
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -1,0 +1,39 @@
+package com.dongtronic.diabot.platforms.discord.commands.quote
+
+import com.dongtronic.diabot.data.QuoteDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import org.slf4j.LoggerFactory
+
+class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
+    private val logger = LoggerFactory.getLogger(QuoteDeleteCommand::class.java)
+
+    init {
+        this.name = "delete"
+        this.help = "Deletes a quote by its ID"
+        this.guildOnly = true
+        this.aliases = arrayOf("remove", "del", "d")
+        this.examples = arrayOf(this.parent!!.name + " delete 1337")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        if (args.isEmpty() || args[0].isBlank()) {
+            event.replyError("No quote ID specified")
+            return
+        }
+
+        if (args[0].toLongOrNull() == null) {
+            event.replyError("Quote ID must be numeric")
+            return
+        }
+
+        if (QuoteDAO.getInstance().getQuote(event.guild.id, args[0]) != null) {
+            QuoteDAO.getInstance().deleteQuote(event.guild.id, args[0])
+            event.replySuccess("Quote #${args[0]} deleted")
+        } else {
+            event.replyError("No quote found for #${args[0]}")
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -25,17 +25,21 @@ class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(c
             event.replyError("No quote ID specified")
             return
         }
-
-        if (args[0].toLongOrNull() == null) {
+        val quoteId = args[0].toLongOrNull()
+        if (quoteId == null) {
             event.replyError("Quote ID must be numeric")
             return
         }
 
-        if (QuoteDAO.getInstance().getQuote(event.guild.id, args[0]) != null) {
-            QuoteDAO.getInstance().deleteQuote(event.guild.id, args[0])
-            event.replySuccess("Quote #${args[0]} deleted")
-        } else {
-            event.replyError("No quote found for #${args[0]}")
-        }
+        QuoteDAO.getInstance().deleteQuote(event.guild.idLong, quoteId).subscribe({
+            if (it.wasAcknowledged()) {
+                event.replySuccess("Quote #$quoteId deleted")
+            } else {
+                event.replyError("No quote found for #$quoteId")
+            }
+        }, {
+            event.replyError("Could not delete quote")
+            logger.error(it.message)
+        })
     }
 }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -4,6 +4,7 @@ import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.api.Permission
 import org.slf4j.LoggerFactory
 
 class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
@@ -14,6 +15,7 @@ class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(c
         this.help = "Deletes a quote by its ID"
         this.guildOnly = true
         this.aliases = arrayOf("remove", "del", "d")
+        this.userPermissions = arrayOf(Permission.MESSAGE_MANAGE)
         this.examples = arrayOf(this.parent!!.name + " delete 1337")
     }
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -39,7 +39,7 @@ class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(c
             }
         }, {
             event.replyError("Could not delete quote")
-            logger.error(it.message)
+            logger.warn("Unexpected error: " + it::class.simpleName + " - " + it.message)
         })
     }
 }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -34,7 +34,7 @@ class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(c
         }
 
         QuoteDAO.getInstance().deleteQuote(event.guild.idLong, quoteId).subscribe({
-            if (it.wasAcknowledged()) {
+            if (it.wasAcknowledged() && it.deletedCount != 0L) {
                 event.replySuccess("Quote #$quoteId deleted")
             } else {
                 event.replyError("No quote found for #$quoteId")

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -18,6 +18,8 @@ class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(c
     }
 
     override fun execute(event: CommandEvent) {
+        if (!QuoteDAO.checkRestrictions(event.textChannel, warnDisabledGuild = true, checkQuoteLimit = false)) return
+
         val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
         if (args.isEmpty() || args[0].isBlank()) {
             event.replyError("No quote ID specified")

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -14,7 +14,7 @@ class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(c
         this.name = "delete"
         this.help = "Deletes a quote by its ID"
         this.guildOnly = true
-        this.aliases = arrayOf("remove", "del", "d")
+        this.aliases = arrayOf("remove", "del", "d", "rm")
         this.userPermissions = arrayOf(Permission.MESSAGE_MANAGE)
         this.examples = arrayOf(this.parent!!.name + " delete 1337")
     }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
@@ -19,6 +19,8 @@ class QuoteEditCommand(category: Category, parent: Command) : DiscordCommand(cat
     }
 
     override fun execute(event: CommandEvent) {
+        if (!QuoteDAO.checkRestrictions(event.textChannel, warnDisabledGuild = true, checkQuoteLimit = false)) return
+
         val match = quoteRegex.matchEntire(event.args)
         if (match == null) {
             event.replyError("Could not parse command. Please make sure you are using the correct format for this command")

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
@@ -1,0 +1,42 @@
+package com.dongtronic.diabot.platforms.discord.commands.quote
+
+import com.dongtronic.diabot.data.QuoteDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import org.slf4j.LoggerFactory
+
+class QuoteEditCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
+    private val quoteRegex = Regex("(?<qid>.*) \"(?<message>[\\s\\S]*)\" ?- ?(?<author>.*[^\\s])")
+    private val logger = LoggerFactory.getLogger(QuoteEditCommand::class.java)
+
+    init {
+        this.name = "edit"
+        this.help = "Edits an existing quote by its ID"
+        this.guildOnly = true
+        this.aliases = arrayOf("e")
+        this.examples = arrayOf(this.parent!!.name + " edit 1337 \"edited quote\" - edited author")
+    }
+
+    override fun execute(event: CommandEvent) {
+        val match = quoteRegex.matchEntire(event.args)
+        if (match == null) {
+            event.replyError("Could not parse command. Please make sure you are using the correct format for this command")
+            return
+        }
+
+        val id = match.groups["qid"]!!.value.trim()
+        val oldQuote = QuoteDAO.getInstance().getQuote(event.guild.id, id)
+        if (oldQuote == null) {
+            event.replyError("No quote found for ID: $id")
+            return
+        }
+
+        val author = match.groups["author"]!!.value.trim()
+        val message = match.groups["message"]!!.value.trim()
+        val dto = oldQuote.copy(author = author, message = message, messageId = event.message.idLong)
+
+        QuoteDAO.getInstance().setQuote(event.guild.id, dto, false)
+        event.replySuccess("Quote #$id edited")
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
@@ -55,7 +55,7 @@ class QuoteEditCommand(category: Category, parent: Command) : DiscordCommand(cat
                 event.replyError("No quote found for #$id")
             } else {
                 event.replyError("Could not edit quote #$id")
-
+                logger.warn("Unexpected error: " + it::class.simpleName + " - " + it.message)
             }
         })
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
@@ -4,6 +4,7 @@ import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.api.Permission
 import org.slf4j.LoggerFactory
 
 class QuoteEditCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
@@ -15,6 +16,7 @@ class QuoteEditCommand(category: Category, parent: Command) : DiscordCommand(cat
         this.help = "Edits an existing quote by its ID"
         this.guildOnly = true
         this.aliases = arrayOf("e")
+        this.userPermissions = arrayOf(Permission.MESSAGE_MANAGE)
         this.examples = arrayOf(this.parent!!.name + " edit 1337 \"edited quote\" - edited author")
     }
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
@@ -38,7 +38,11 @@ class QuoteEditCommand(category: Category, parent: Command) : DiscordCommand(cat
         val oldQuote = QuoteDAO.getInstance().getQuote(event.guild.idLong, id)
 
         oldQuote.flatMap {
-            val dto = it.copy(author = author, message = message, messageId = event.message.idLong)
+            val dto = it.copy(
+                    author = author,
+                    message = message,
+                    messageId = event.message.idLong,
+                    channelId = event.channel.idLong)
             QuoteDAO.getInstance().updateQuote(dto)
         }.subscribe({
             if (it.wasAcknowledged()) {

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -31,10 +31,11 @@ class QuoteListener : ListenerAdapter() {
         }
 
         val quoteMessage = Consumer<Message> { message ->
+            val name = message.member?.effectiveName ?: message.author.name
             QuoteDAO.getInstance().addQuote(QuoteDTO(
                     guildId = guild.idLong,
                     channelId = event.channel.idLong,
-                    author = message.author.name,
+                    author = name,
                     authorId = message.author.idLong,
                     message = message.contentRaw,
                     messageId = message.idLong

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -14,6 +14,7 @@ class QuoteListener : ListenerAdapter() {
     override fun onGuildMessageReactionAdd(event: GuildMessageReactionAddEvent) {
         if (event.user.isBot) return
         if (event.reaction.reactionEmote.asCodepoints != speechEmoji) return
+        if (!QuoteDAO.checkRestrictions(event.channel)) return
 
         val author = event.member
         val guild = event.guild

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -41,7 +41,7 @@ class QuoteListener : ListenerAdapter() {
                     messageId = message.idLong
             )).subscribe({
                 message.addReaction(speechEmoji).queue()
-                event.channel.sendMessage("New quote added by ${author.user.name} as #${it.quoteId}").queue()
+                event.channel.sendMessage("New quote added by ${author.effectiveName} as #${it.quoteId}").queue()
             }, {
                 event.channel.sendMessage("Could not create quote for message: ${message.id}").queue()
             })

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -1,0 +1,37 @@
+package com.dongtronic.diabot.platforms.discord.listeners
+
+import com.dongtronic.diabot.data.QuoteDAO
+import com.dongtronic.diabot.data.QuoteDTO
+import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionAddEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.slf4j.LoggerFactory
+
+class QuoteListener : ListenerAdapter() {
+    // https://emojiguide.org/speech-balloon
+    private val speechEmoji = "U+1f4ac"
+    private val logger = LoggerFactory.getLogger(QuoteListener::class.java)
+
+    override fun onGuildMessageReactionAdd(event: GuildMessageReactionAddEvent) {
+        if (event.user.isBot) return
+        if (event.reaction.reactionEmote.asCodepoints != speechEmoji) return
+
+        val author = event.member
+        val guild = event.guild
+
+        event.channel.retrieveMessageById(event.messageId).queue {
+            val quote = QuoteDAO.getInstance().addQuote(guild.id, QuoteDTO(
+                    author = it.author.name,
+                    authorId = it.author.idLong,
+                    message = it.contentRaw,
+                    messageId = it.idLong
+            ))
+
+            if (quote != null) {
+                it.addReaction(speechEmoji).queue()
+                event.channel.sendMessage("New quote added by ${author.user.name} as #${quote.id}").queue()
+            } else {
+                event.channel.sendMessage("Could not create quote for message: ${it.id}").queue()
+            }
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -22,6 +22,7 @@ class QuoteListener : ListenerAdapter() {
         event.channel.retrieveMessageById(event.messageId).queue { message ->
             QuoteDAO.getInstance().addQuote(QuoteDTO(
                     guildId = guild.idLong,
+                    channelId = event.channel.idLong,
                     author = message.author.name,
                     authorId = message.author.idLong,
                     message = message.contentRaw,

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -2,9 +2,14 @@ package com.dongtronic.diabot.platforms.discord.listeners
 
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
+import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionAddEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.litote.kmongo.eq
 import org.slf4j.LoggerFactory
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
+import java.util.function.Consumer
 
 class QuoteListener : ListenerAdapter() {
     // https://emojiguide.org/speech-balloon
@@ -19,7 +24,13 @@ class QuoteListener : ListenerAdapter() {
         val author = event.member
         val guild = event.guild
 
-        event.channel.retrieveMessageById(event.messageId).queue { message ->
+        val messageRetrieval = Mono.defer {
+            // defer to prevent retrieving message until subscribe
+            event.channel.retrieveMessageById(event.messageId)
+                .submit().toMono()
+        }
+
+        val quoteMessage = Consumer<Message> { message ->
             QuoteDAO.getInstance().addQuote(QuoteDTO(
                     guildId = guild.idLong,
                     channelId = event.channel.idLong,
@@ -34,5 +45,16 @@ class QuoteListener : ListenerAdapter() {
                 event.channel.sendMessage("Could not create quote for message: ${message.id}").queue()
             })
         }
+
+        QuoteDAO.getInstance()
+                // search for any quotes with this message ID
+                .getQuotes(guild.idLong, QuoteDTO::messageId eq event.messageIdLong)
+                .toMono()
+                .subscribe({/*ignored*/}, {
+                    if (it is NoSuchElementException) {
+                        // if there is no quotes then proceed
+                        messageRetrieval.subscribe(quoteMessage)
+                    }
+                })
     }
 }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -19,20 +19,19 @@ class QuoteListener : ListenerAdapter() {
         val author = event.member
         val guild = event.guild
 
-        event.channel.retrieveMessageById(event.messageId).queue {
-            val quote = QuoteDAO.getInstance().addQuote(guild.id, QuoteDTO(
-                    author = it.author.name,
-                    authorId = it.author.idLong,
-                    message = it.contentRaw,
-                    messageId = it.idLong
-            ))
-
-            if (quote != null) {
-                it.addReaction(speechEmoji).queue()
-                event.channel.sendMessage("New quote added by ${author.user.name} as #${quote.id}").queue()
-            } else {
-                event.channel.sendMessage("Could not create quote for message: ${it.id}").queue()
-            }
+        event.channel.retrieveMessageById(event.messageId).queue { message ->
+            QuoteDAO.getInstance().addQuote(QuoteDTO(
+                    guildId = guild.idLong,
+                    author = message.author.name,
+                    authorId = message.author.idLong,
+                    message = message.contentRaw,
+                    messageId = message.idLong
+            )).subscribe({
+                message.addReaction(speechEmoji).queue()
+                event.channel.sendMessage("New quote added by ${author.user.name} as #${it.quoteId}").queue()
+            }, {
+                event.channel.sendMessage("Could not create quote for message: ${message.id}").queue()
+            })
         }
     }
 }

--- a/src/main/java/com/dongtronic/diabot/util/MongoDB.kt
+++ b/src/main/java/com/dongtronic/diabot/util/MongoDB.kt
@@ -1,0 +1,41 @@
+package com.dongtronic.diabot.util
+
+import com.mongodb.reactivestreams.client.MongoCollection
+import com.mongodb.reactivestreams.client.MongoDatabase
+import org.bson.conversions.Bson
+import org.litote.kmongo.reactivestreams.KMongo
+import org.litote.kmongo.reactivestreams.find
+import org.litote.kmongo.reactivestreams.findOne
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+class MongoDB {
+    val client = KMongo.createClient(System.getenv("MONGO_URI"))
+    val database: MongoDatabase = client.getDatabase("diabot")
+
+    companion object {
+        private var instance: MongoDB? = null
+
+        fun getInstance(): MongoDB {
+            if (instance == null) {
+                instance = MongoDB()
+            }
+            return instance as MongoDB
+        }
+    }
+}
+fun <T> MongoCollection<T>.findOne(vararg filter: Bson): Mono<T> {
+    return Mono.from(findOne(*filter)).errorOnEmpty()
+}
+
+fun <T> MongoCollection<T>.findMany(vararg filter: Bson): Flux<T> {
+    return Flux.from(find(*filter)).errorOnEmpty()
+}
+
+fun <T> Mono<T>.errorOnEmpty(): Mono<T> {
+    return switchIfEmpty(Mono.error(NoSuchElementException()))
+}
+
+fun <T> Flux<T>.errorOnEmpty(): Flux<T> {
+    return switchIfEmpty(Flux.error(NoSuchElementException()))
+}

--- a/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
+++ b/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
@@ -28,15 +28,6 @@ object RedisKeyFormats {
     const val ruleTitle = "{{guildid}}:rules:{{ruleid}}:title"
     const val ruleMessage = "{{guildid}}:rules:{{ruleid}}:message"
 
-    // Quotes
-    const val quoteIds = "{{guildid}}:quotes"
-    const val quoteIndex = "{{guildid}}:quotes:index"
-    const val quoteAuthor = "{{guildid}}:quotes:{{quoteid}}:author"
-    const val quoteAuthorId = "{{guildid}}:quotes:{{quoteid}}:authorid"
-    const val quoteMessage = "{{guildid}}:quotes:{{quoteid}}:message"
-    const val quoteMessageId = "{{guildid}}:quotes:{{quoteid}}:messageid"
-    const val quoteTime = "{{guildid}}:quotes:{{quoteid}}:time"
-
     // Project info
     const val infoList = "info:projects"
     const val infoText = "info:{{project}}"

--- a/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
+++ b/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
@@ -32,7 +32,9 @@ object RedisKeyFormats {
     const val quoteIds = "{{guildid}}:quotes"
     const val quoteIndex = "{{guildid}}:quotes:index"
     const val quoteAuthor = "{{guildid}}:quotes:{{quoteid}}:author"
+    const val quoteAuthorId = "{{guildid}}:quotes:{{quoteid}}:authorid"
     const val quoteMessage = "{{guildid}}:quotes:{{quoteid}}:message"
+    const val quoteMessageId = "{{guildid}}:quotes:{{quoteid}}:messageid"
     const val quoteTime = "{{guildid}}:quotes:{{quoteid}}:time"
 
     // Project info

--- a/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
+++ b/src/main/java/com/dongtronic/diabot/util/RedisKeyFormats.kt
@@ -28,6 +28,13 @@ object RedisKeyFormats {
     const val ruleTitle = "{{guildid}}:rules:{{ruleid}}:title"
     const val ruleMessage = "{{guildid}}:rules:{{ruleid}}:message"
 
+    // Quotes
+    const val quoteIds = "{{guildid}}:quotes"
+    const val quoteIndex = "{{guildid}}:quotes:index"
+    const val quoteAuthor = "{{guildid}}:quotes:{{quoteid}}:author"
+    const val quoteMessage = "{{guildid}}:quotes:{{quoteid}}:message"
+    const val quoteTime = "{{guildid}}:quotes:{{quoteid}}:time"
+
     // Project info
     const val infoList = "info:projects"
     const val infoText = "info:{{project}}"


### PR DESCRIPTION
This PR has a few changes unrelated to quotes in it:
1. Kotlin was updated to 1.3.72 from 1.2.51
2. Gradle was updated to 4.9 from 4.8 (necessary for Kotlin 1.3)
3. A MongoDB driver, along with Project Reactor, was added as dependencies to allow migrating away from Redis in the future

With MongoDB, the connection string must be specified under `MONGO_URI` and there must be a database called `diabot` with R/W permissions for it and all collections under it. For the quoting functionality, it requires two collections in MongoDB named `quotes` and `quote-index`.

---

With the quoting system, it has restrictions enabled on it by default which prevents guilds not listed in the `QUOTE_ENABLE_GUILDS` variable from using it. It also prevents the number of quotes in a guild from exceeding `QUOTE_MAX`.

A summary of the env vars added in this PR can be found below.
| Environment variable | Description |
| ------------- | ------------- |
| MONGO_URI | [MongoDB connection string](https://docs.mongodb.com/manual/reference/connection-string/) |
| QUOTE_ENABLE_GUILDS | Guild IDs which have the quoting functionality enabled. By default, all guilds are forbidden from using the quoting system. Guild IDs are separated by commas `,` |
| QUOTE_MAX | The maximum amount of quotes allowed per guild. If this is reached then no more quotes can be added. The default is 5000 quotes. |