### PR TITLE
Quote improvements

### DIFF
--- a/src/main/java/com/dongtronic/diabot/Main.kt
+++ b/src/main/java/com/dongtronic/diabot/Main.kt
@@ -105,6 +105,8 @@ object Main {
         // Custom help handler
         client.setHelpConsumer(HelpListener())
 
+        val builtClient = client.build()
+
         // start getting a bot account set up
         JDABuilder(token)
                 // set the game for when the bot is loading
@@ -114,12 +116,12 @@ object Main {
                 // add the listeners
                 .addEventListeners(
                         waiter,
-                        client.build(),
+                        builtClient,
                         ConversionListener(),
                         RewardListener(),
                         UsernameEnforcementListener(),
                         OhNoListener(),
-                        QuoteListener()
+                        QuoteListener(builtClient)
                 )
                 // start it up!
                 .build()

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -6,6 +6,7 @@ import com.dongtronic.diabot.util.findOne
 import com.dongtronic.diabot.util.findOneRandom
 import com.mongodb.client.model.Filters.and
 import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.IndexOptions
 import com.mongodb.client.model.ReturnDocument
 import com.mongodb.client.model.Updates
 import com.mongodb.client.result.DeleteResult
@@ -13,6 +14,7 @@ import com.mongodb.client.result.UpdateResult
 import com.mongodb.reactivestreams.client.MongoCollection
 import net.dv8tion.jda.api.entities.TextChannel
 import org.bson.conversions.Bson
+import org.litote.kmongo.descending
 import org.litote.kmongo.eq
 import org.litote.kmongo.reactivestreams.updateOne
 import org.slf4j.LoggerFactory
@@ -31,6 +33,14 @@ class QuoteDAO private constructor() {
     private val logger = LoggerFactory.getLogger(QuoteDAO::class.java)
     val enabledGuilds = System.getenv().getOrDefault("QUOTE_ENABLE_GUILDS", "").split(",")
     val maxQuotes = System.getenv().getOrDefault("QUOTE_MAX", "5000").toIntOrNull() ?: 5000
+
+    init {
+        // Create a unique index
+        val options = IndexOptions().unique(true).name(QuoteDTO::guildId.name)
+        quoteIndexes!!.createIndex(descending(QuoteDTO::guildId), options).toMono()
+                .subscribeOn(scheduler)
+                .subscribe()
+    }
 
     /**
      * Gets a [QuoteDTO] from a quote ID

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -22,17 +22,15 @@ import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.toMono
 
 class QuoteDAO private constructor() {
-    private var collection: MongoCollection<QuoteDTO>? = null
-    private var quoteIndexes: MongoCollection<QuoteIndexDTO>? = null
+    val collection: MongoCollection<QuoteDTO>?
+            = MongoDB.getInstance().database.getCollection("quotes", QuoteDTO::class.java)
+    val quoteIndexes: MongoCollection<QuoteIndexDTO>?
+            = MongoDB.getInstance().database.getCollection("quote-index", QuoteIndexDTO::class.java)
+
     private val scheduler = Schedulers.boundedElastic()
     private val logger = LoggerFactory.getLogger(QuoteDAO::class.java)
     val enabledGuilds = System.getenv().getOrDefault("QUOTE_ENABLE_GUILDS", "").split(",")
     val maxQuotes = System.getenv().getOrDefault("QUOTE_MAX", "5000").toIntOrNull() ?: 5000
-
-    init {
-        collection = MongoDB.getInstance().database.getCollection("quotes", QuoteDTO::class.java)
-        quoteIndexes = MongoDB.getInstance().database.getCollection("quote-index", QuoteIndexDTO::class.java)
-    }
 
     /**
      * Gets a [QuoteDTO] from a quote ID

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -3,6 +3,7 @@ package com.dongtronic.diabot.data
 import com.dongtronic.diabot.util.MongoDB
 import com.dongtronic.diabot.util.findMany
 import com.dongtronic.diabot.util.findOne
+import com.dongtronic.diabot.util.findOneRandom
 import com.mongodb.client.model.Filters.and
 import com.mongodb.client.model.FindOneAndUpdateOptions
 import com.mongodb.client.model.ReturnDocument
@@ -42,6 +43,38 @@ class QuoteDAO private constructor() {
      */
     fun getQuote(guildId: Long, quoteId: Long): Mono<QuoteDTO> {
         return collection!!.findOne(filter(guildId, quoteId)).subscribeOn(scheduler)
+    }
+
+    /**
+     * Returns all quotes defined under a guild matching the given filter, if any
+     *
+     * @param guildId guild ID
+     * @param filter the mongo filter to match against, if any
+     * @return all quotes matching the filter for the specified guild
+     */
+    fun getQuotes(guildId: Long, filter: Bson? = null): Flux<QuoteDTO> {
+        val joinedFilter = if (filter != null)
+            and(filter(guildId), filter)
+        else
+            filter(guildId)
+
+        return collection!!.findMany(joinedFilter).subscribeOn(scheduler)
+    }
+
+    /**
+     * Returns a random quote defined under a guild matching the given filter, if any
+     *
+     * @param guildId guild ID
+     * @param filter the mongo filter to match against, if any
+     * @return a random quote matching the filter for the specified guild
+     */
+    fun getRandomQuote(guildId: Long, filter: Bson? = null): Mono<QuoteDTO> {
+        val joinedFilter = if (filter != null)
+            and(filter(guildId), filter)
+        else
+            filter(guildId)
+
+        return collection!!.findOneRandom(joinedFilter).subscribeOn(scheduler)
     }
 
     /**
@@ -86,22 +119,6 @@ class QuoteDAO private constructor() {
     fun deleteQuote(guildId: Long, quoteId: Long): Mono<DeleteResult> {
         return collection!!.deleteOne(filter(guildId, quoteId))
                 .toMono().subscribeOn(scheduler)
-    }
-
-    /**
-     * Returns all quotes defined under a guild matching the given filter, if any
-     *
-     * @param guildId guild ID
-     * @param filter the mongo filter to match against, if any
-     * @return all quotes matching the filter for the specified guild
-     */
-    fun getQuotes(guildId: Long, filter: Bson? = null): Flux<QuoteDTO> {
-        val joinedFilter = if (filter != null)
-            and(filter(guildId), filter)
-        else
-            filter(guildId)
-
-        return collection!!.findMany(joinedFilter).subscribeOn(scheduler)
     }
 
     /**

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -3,11 +3,11 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.slf4j.LoggerFactory
 
-class QuoteAddCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
+class QuoteAddCommand(category: Category, parent: QuoteCommand) : DiscordCommand(category, parent) {
+    private val mentionsRegex = parent.mentionsRegex
     private val quoteRegex = Regex("\"(?<message>[\\s\\S]*)\" ?- ?(?<author>.*[^\\s])")
     private val logger = LoggerFactory.getLogger(QuoteAddCommand::class.java)
 
@@ -22,17 +22,30 @@ class QuoteAddCommand(category: Category, parent: Command) : DiscordCommand(cate
     override fun execute(event: CommandEvent) {
         if (!QuoteDAO.checkRestrictions(event.textChannel, warnDisabledGuild = true)) return
 
-        val match = quoteRegex.matchEntire(event.args)
+        val match = quoteRegex.find(event.message.contentRaw)
         if (match == null) {
             event.replyError("Could not parse quote. Please make sure you are using the correct format for this command")
             return
         }
-        val author = match.groups["author"]!!.value.trim()
+
+        var authorId = 0L
+        var author = match.groups["author"]!!.value.trim()
         val message = match.groups["message"]!!.value.trim()
+
+        val mention = mentionsRegex.matchEntire(author)
+        if (mention != null) {
+            val mentioned = event.message.mentionedMembers.lastOrNull()
+            val uid = mention.groups["uid"]!!.value.trim().toLongOrNull()
+            if (mentioned != null && uid != null) {
+                author = mentioned.user.name
+                authorId = uid
+            }
+        }
 
         val quoteDto = QuoteDTO(guildId = event.guild.idLong,
                 channelId = event.channel.idLong,
                 author = author,
+                authorId = authorId,
                 message = message,
                 messageId = event.message.idLong)
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -13,7 +13,7 @@ import reactor.core.publisher.Mono
 import java.time.Instant
 
 class QuoteCommand(category: Category) : DiscordCommand(category, null) {
-    private val mentionsRegex = Regex("<@(?<uid>\\d+)>")
+    val mentionsRegex = Regex("<@!(?<uid>\\d+)>")
     private val discordMessageLink = "https://discordapp.com/channels/{{guild}}/{{channel}}/{{message}}"
     private val logger = LoggerFactory.getLogger(QuoteCommand::class.java)
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -26,7 +26,8 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
         this.children = arrayOf(
                 QuoteAddCommand(category, this),
                 QuoteDeleteCommand(category, this),
-                QuoteEditCommand(category, this))
+                QuoteEditCommand(category, this),
+                QuoteImportCommand(category, this))
     }
 
     override fun execute(event: CommandEvent) {

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -101,7 +101,7 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
      * @return a random [QuoteDTO], or null if none found
      */
     private fun getRandomQuote(guildId: Long, filter: Bson? = null): Mono<QuoteDTO> {
-        return QuoteDAO.getInstance().getQuotes(guildId, filter).collectList().map { it.random() }
+        return QuoteDAO.getInstance().getRandomQuote(guildId, filter)
     }
 
     /**

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteImportCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteImportCommand.kt
@@ -1,0 +1,322 @@
+package com.dongtronic.diabot.platforms.discord.commands.quote
+
+import com.dongtronic.diabot.data.QuoteDAO
+import com.dongtronic.diabot.data.QuoteDTO
+import com.dongtronic.diabot.exceptions.RequestStatusException
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.GenericEvent
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.hooks.EventListener
+import net.dv8tion.jda.internal.requests.Requester
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.litote.kmongo.eq
+import org.slf4j.LoggerFactory
+import reactor.core.Exceptions
+import reactor.core.publisher.DirectProcessor
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import reactor.kotlin.core.publisher.toFlux
+import reactor.kotlin.core.publisher.toMono
+import java.io.IOException
+import java.net.MalformedURLException
+import java.net.URISyntaxException
+import java.net.URL
+import java.time.Duration
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicLong
+
+class QuoteImportCommand(category: Category, parent: QuoteCommand) : DiscordCommand(category, parent), EventListener {
+    private val mapper = jacksonObjectMapper()
+    private val logger = LoggerFactory.getLogger(QuoteImportCommand::class.java)
+    private val pendingRequests = mutableSetOf<User>()
+    private var guildMessages = DirectProcessor.create<GuildMessageReceivedEvent>()
+    private var eventListening = false
+
+    init {
+        this.name = "import"
+        this.help = "Imports UB3R-B0T quotes from a JSON file, either provided via a URL or a file attachment"
+        this.guildOnly = true
+        this.ownerCommand = true
+        this.hidden = true
+        this.aliases = arrayOf()
+        this.examples = arrayOf(this.parent!!.name + " import <URL>", this.parent.name + " import")
+    }
+
+    override fun execute(event: CommandEvent) {
+        registerListener(event.jda)
+
+        if (!QuoteDAO.checkRestrictions(event.textChannel, warnDisabledGuild = true)) return
+        if (pendingRequests.contains(event.author)) return
+        pendingRequests.add(event.author)
+
+        if (event.args.isNotBlank() || event.message.attachments.isNotEmpty()) {
+            parse(event)
+            return
+        }
+
+        // create an interactive session:
+        // listens for a URL or attachment from the user's next message
+        guildMessages.filter { it.author == event.author && it.channel == event.channel && it.guild == event.guild }
+                .map { it.message }
+                .toMono()
+                .timeout(Duration.ofSeconds(90))
+                .subscribeOn(Schedulers.parallel())
+                .doOnSubscribe {
+                    // send the initial message
+                    event.reply("${event.author.asMention} - Type a URL, attach a file, or type `cancel`")
+                }
+                .subscribe({
+                    if (it.contentStripped == "cancel") {
+                        pendingRequests.remove(event.author)
+                        event.replySuccess("${event.author.asMention} - Import cancelled")
+                        return@subscribe
+                    }
+
+                    parse(event, it.contentDisplay, it)
+                }, {
+                    pendingRequests.remove(event.author)
+                    if (it is TimeoutException) {
+                        event.replyWarning("${event.author.asMention} - Import timed out")
+                    }
+                })
+    }
+
+    /**
+     * Registers this event listener *once*
+     *
+     * @param jda The JDA client instance to register under
+     */
+    private fun registerListener(jda: JDA) {
+        if (!eventListening) {
+            eventListening = true
+            jda.addEventListener(this)
+        }
+    }
+
+    /**
+     * Parses the incoming import request and begins the task of importing.
+     *
+     * @param event The command event which this request came from.
+     * If the request came from interactive mode, this will be the `diabot quote import` event.
+     *
+     * @param args Optional. The command's arguments, which should consist of a URL if that is being used.
+     * If the request came from interactive mode, this will be the second message's contents.
+     *
+     * @param message Optional. The request's [Message] instance.
+     * If the request came from interactive mode, this will be the second message.
+     */
+    private fun parse(event: CommandEvent, args: String = event.args, message: Message = event.message) {
+        val mention = event.author.asMention + " -"
+        val successful = AtomicLong()
+        val failed = AtomicLong()
+        val startTime = System.currentTimeMillis()
+
+        val importQuotes = if (message.attachments.isNotEmpty()) {
+            getAttachmentsText(message.attachments)
+        } else {
+            getUrlText(args)
+        }.subscribeOn(Schedulers.boundedElastic())
+                // Delete the message which has the file/attachment once retrieved and indicate the task started
+                .doFinally {
+                    // if we delete their first message then send a new message
+                    if (message == event.message) {
+                        event.reply("$mention Starting import task..")
+                    } else {
+                        event.reactSuccess()
+                    }
+
+                    message.delete().queue()
+                }
+                // Map from JSON to data class
+                .flatMapMany { mapper.readValue<List<Ub3rQuote>>(it).toFlux() }
+                // Upsert
+                .flatMap {
+                    if (it.server.isNotBlank() && it.server != event.guild.id) {
+                        return@flatMap Mono.error<QuoteDTO>(IllegalArgumentException("Quotes must be from the current server"))
+                    }
+
+                    val diabotQuote = it.toDiabotQuote(event.guild)
+                    upsertQuote(diabotQuote)
+                            // Used for final statistics
+                            .doOnNext { successful.getAndIncrement() }
+                            .onErrorContinue { throwable, quote ->
+                                failed.getAndIncrement()
+                                logger.warn("Could not import $quote - $throwable")
+                            }
+                }
+                // Unwrap throwables from `ReactiveException`
+                .onErrorMap(Exceptions::unwrap)
+                // Remove user from the pending requests once all quotes have been processed
+                .doFinally { pendingRequests.remove(message.author) }
+
+        importQuotes.subscribe({
+            // on each
+            logger.debug("Finished adding $it")
+        }, {
+            // on error
+            var errorMessage = "Import failed: ${it::class.simpleName} - ${it.message}"
+            when (it) {
+                is IllegalArgumentException -> {
+                    errorMessage = "Invalid argument: ${it.message}"
+                }
+                is MalformedURLException,
+                is URISyntaxException -> {
+                    errorMessage = "Provided URL was invalid"
+                    logger.warn("Invalid URL: " + it::class.simpleName + " - " + it.message)
+                }
+                is IOException -> {
+                    errorMessage = "Could not load input"
+                    logger.warn("IO error: " + it::class.simpleName + " - " + it.message)
+                }
+                else -> {
+                    logger.warn("Unexpected error: " + it::class.simpleName + " - " + it.message + " - " + it.stackTrace)
+                }
+            }
+
+            event.replyError("$mention $errorMessage")
+        }, {
+            // on finish
+            val totalTime = System.currentTimeMillis() - startTime
+            event.replySuccess("$mention Finished importing quotes: ${successful.get()} successful, ${failed.get()} unsuccessful in $totalTime ms.")
+        })
+    }
+
+    /**
+     * Inserts a quote into the database if it does not exist, otherwise it will update the existing quote.
+     *
+     * @param quoteDTO The quote to upsert
+     * @return The quote which was upserted
+     */
+    private fun upsertQuote(quoteDTO: QuoteDTO): Mono<QuoteDTO> {
+        val quoteDAO = QuoteDAO.getInstance()
+        var query = quoteDAO.collection.countDocuments(QuoteDTO::quoteId eq quoteDTO.quoteId).toMono()
+
+        if (quoteDTO.quoteId == null) {
+            // skip getting count as there will be no matches
+            query = Mono.just(0L)
+        }
+
+        return query.flatMap { count ->
+            if (count == 0L) {
+                // if there's no quotes matching this ID then add it
+                return@flatMap quoteDAO.addQuote(quoteDTO)
+            }
+
+            // otherwise, update the quote with the matching ID
+            quoteDAO.updateQuote(quoteDTO).flatMap {
+                if (it.matchedCount == 0L) {
+                    Mono.error(NoSuchElementException())
+                } else {
+                    quoteDTO.toMono()
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets an attachment with a `.json` filename and returns its text
+     *
+     * @param attachments A list of the attachments
+     * @return The JSON attachment's contents, if any
+     */
+    @Suppress("ReactiveStreamsUnusedPublisher")
+    private fun getAttachmentsText(attachments: List<Message.Attachment>): Mono<String> {
+        val attachment = attachments.firstOrNull { it.fileName.endsWith(".json") }?.url
+
+        return if (attachment != null)
+            getUrlText(attachment)
+        else
+            Mono.error(IllegalArgumentException("Could not open attachment"))
+    }
+
+    /**
+     * Grabs the URL's contents
+     *
+     * @param url The URL to grab contents of
+     * @return The contents of the URL
+     */
+    private fun getUrlText(url: String): Mono<String> {
+        return Mono.fromCallable {
+            val client = OkHttpClient()
+            val request = Request.Builder()
+                    .get()
+                    .url(URL(url))
+                    .addHeader("user-agent", Requester.USER_AGENT)
+                    .build()
+
+            client.newCall(request).execute().use { response ->
+                val body = response.body()
+                if (!response.isSuccessful || body == null) {
+                    throw RequestStatusException(response.code())
+                }
+
+                body.string()
+            }
+        }
+    }
+
+    /**
+     * Listens to incoming messages for the interactive mode
+     */
+    override fun onEvent(event: GenericEvent) {
+        if (event !is GuildMessageReceivedEvent) return
+
+        if (event.author.isBot) return
+
+        guildMessages.onNext(event)
+    }
+
+    /**
+     * A data class representing UB3R-B0T quotes in JSON form
+     */
+    @JsonAutoDetect
+    data class Ub3rQuote(
+            val id: String,
+            val nick: String,
+            val userId: String,
+            val channel: String? = null,
+            val server: String,
+            val text: String,
+            val messageId: String,
+            val time: Long,
+            val dateTime: String
+    ) {
+        /**
+         * Converts this UB3R-B0T quote into a Diabot [QuoteDTO]
+         *
+         * @param guild The guild which this quote belongs to. This is used for looking up channel and guild IDs.
+         * May be null, however the `server` parameter *must* be convertable to [Long].
+         * @return Converted quote object
+         */
+        fun toDiabotQuote(guild: Guild? = null): QuoteDTO {
+            val quoteId = id.toLongOrNull()
+            val guildId = server.toLongOrNull() ?: guild!!.idLong
+            // looks up the channel name and tries to get its id
+            // the channel key can be missing, which is why we need a null check
+            val channelId = if (channel != null)
+                guild?.textChannels?.firstOrNull { it.name == channel }?.idLong ?: 0
+            else
+                0
+            val messageIdLong = messageId.toLongOrNull() ?: 0
+            val authorId = userId.toLongOrNull() ?: 0
+
+            return QuoteDTO(quoteId = quoteId,
+                    guildId = guildId,
+                    channelId = channelId,
+                    author = nick,
+                    authorId = authorId,
+                    message = text,
+                    messageId = messageIdLong,
+                    time = time)
+        }
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -6,6 +6,7 @@ import com.dongtronic.diabot.platforms.discord.commands.quote.QuoteCommand
 import com.jagrosh.jdautilities.command.CommandClient
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageType
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionAddEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
@@ -64,10 +65,12 @@ class QuoteListener(private val client: CommandClient) : ListenerAdapter() {
                 // search for any quotes with this message ID
                 .getQuotes(guild.idLong, QuoteDTO::messageId eq event.messageIdLong)
                 .toMono()
-                .subscribe({/*ignored*/}, {
-                    if (it is NoSuchElementException) {
-                        // if there is no quotes then proceed
-                        messageRetrieval.subscribe(quoteMessage)
+                .subscribe({/*ignored*/}, { error ->
+                    // if there are no quotes then proceed
+                    if (error is NoSuchElementException) {
+                        messageRetrieval
+                                .filter { it.type == MessageType.DEFAULT && !it.author.isBot }
+                                .subscribe(quoteMessage)
                     }
                 })
     }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -31,11 +31,10 @@ class QuoteListener : ListenerAdapter() {
         }
 
         val quoteMessage = Consumer<Message> { message ->
-            val name = message.member?.effectiveName ?: message.author.name
             QuoteDAO.getInstance().addQuote(QuoteDTO(
                     guildId = guild.idLong,
                     channelId = event.channel.idLong,
-                    author = name,
+                    author = message.author.name,
                     authorId = message.author.idLong,
                     message = message.contentRaw,
                     messageId = message.idLong

--- a/src/main/java/com/dongtronic/diabot/util/MongoDB.kt
+++ b/src/main/java/com/dongtronic/diabot/util/MongoDB.kt
@@ -1,11 +1,12 @@
 package com.dongtronic.diabot.util
 
+import com.mongodb.client.model.Collation
+import com.mongodb.client.model.CollationStrength
 import com.mongodb.reactivestreams.client.MongoCollection
 import com.mongodb.reactivestreams.client.MongoDatabase
 import org.bson.conversions.Bson
 import org.litote.kmongo.reactivestreams.KMongo
 import org.litote.kmongo.reactivestreams.find
-import org.litote.kmongo.reactivestreams.findOne
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -24,12 +25,21 @@ class MongoDB {
         }
     }
 }
+
+/**
+ * Collation for case-insensitive queries
+ */
+val caseCollation: Collation = Collation.builder()
+        .collationStrength(CollationStrength.SECONDARY)
+        .locale("en")
+        .build()
+
 fun <T> MongoCollection<T>.findOne(vararg filter: Bson): Mono<T> {
-    return Mono.from(findOne(*filter)).errorOnEmpty()
+    return Mono.from(find(*filter).collation(caseCollation)).errorOnEmpty()
 }
 
 fun <T> MongoCollection<T>.findMany(vararg filter: Bson): Flux<T> {
-    return Flux.from(find(*filter)).errorOnEmpty()
+    return Flux.from(find(*filter).collation(caseCollation)).errorOnEmpty()
 }
 
 fun <T> Mono<T>.errorOnEmpty(): Mono<T> {

--- a/src/main/java/com/dongtronic/diabot/util/MongoDB.kt
+++ b/src/main/java/com/dongtronic/diabot/util/MongoDB.kt
@@ -1,5 +1,7 @@
 package com.dongtronic.diabot.util
 
+import com.mongodb.ConnectionString
+import com.mongodb.MongoClientSettings
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CollationStrength
 import com.mongodb.reactivestreams.client.MongoCollection
@@ -13,9 +15,17 @@ import org.litote.kmongo.reactivestreams.find
 import org.litote.kmongo.sample
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.util.concurrent.TimeUnit
 
 class MongoDB {
-    val client = KMongo.createClient(System.getenv("MONGO_URI"))
+    private val clientSettings: MongoClientSettings = MongoClientSettings.builder()
+            .applyToConnectionPoolSettings {
+                // close connections after 1 hour of inactivity
+                it.maxConnectionIdleTime(60, TimeUnit.MINUTES)
+            }
+            .applyConnectionString(ConnectionString(System.getenv("MONGO_URI")))
+            .build()
+    val client = KMongo.createClient(clientSettings)
     val database: MongoDatabase = client.getDatabase("diabot")
 
     companion object {

--- a/src/main/java/com/dongtronic/diabot/util/MongoDB.kt
+++ b/src/main/java/com/dongtronic/diabot/util/MongoDB.kt
@@ -5,8 +5,12 @@ import com.mongodb.client.model.CollationStrength
 import com.mongodb.reactivestreams.client.MongoCollection
 import com.mongodb.reactivestreams.client.MongoDatabase
 import org.bson.conversions.Bson
+import org.litote.kmongo.and
+import org.litote.kmongo.match
 import org.litote.kmongo.reactivestreams.KMongo
+import org.litote.kmongo.reactivestreams.aggregate
 import org.litote.kmongo.reactivestreams.find
+import org.litote.kmongo.sample
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -36,6 +40,12 @@ val caseCollation: Collation = Collation.builder()
 
 fun <T> MongoCollection<T>.findOne(vararg filter: Bson): Mono<T> {
     return Mono.from(find(*filter).collation(caseCollation)).errorOnEmpty()
+}
+
+inline fun <reified T : Any> MongoCollection<T>.findOneRandom(vararg filter: Bson): Mono<T> {
+    val filters = match(and(*filter))
+    val count = sample(1)
+    return Mono.from(aggregate<T>(filters, count).collation(caseCollation)).errorOnEmpty()
 }
 
 fun <T> MongoCollection<T>.findMany(vararg filter: Bson): Flux<T> {


### PR DESCRIPTION
This PR improves a few areas of quotes:
- quote searches by author name are case insensitive: `diabot quote gArLiC sPrEaD`
- quotes will only be created via reactions if the message is sent by a non-bot account
- quotes created via reactions save the author name as their account username instead of guild nickname
- quotes created via reactions will only respond if the reacting user can send messages in the channel
- the quote command can be called with a `.` prefix in place of `diabot`: `.quote garlic spread`
- use mongodb-based random quote grabbing
- if adding a quote manually (via `diabot quote add`) and the author is a mention, change the author name and ID to the mentioned user's name and ID
- close mongodb connections after 1 hour of inactivity
- add an importer for UB3R-B0T quotes