### PR TITLE
Logging improvements

### DIFF
--- a/src/main/java/com/dongtronic/diabot/data/AdminDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/AdminDAO.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.data
 
+import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
-import org.slf4j.LoggerFactory
 import redis.clients.jedis.Jedis
 
 class AdminDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger = LoggerFactory.getLogger(AdminDAO::class.java)
+    private val logger by Logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/AdminDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/AdminDAO.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.data
 
-import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
+import com.dongtronic.diabot.util.logger
 import redis.clients.jedis.Jedis
 
 class AdminDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger by Logger()
+    private val logger = logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/InfoDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/InfoDAO.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.data
 
-import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
+import com.dongtronic.diabot.util.logger
 import redis.clients.jedis.Jedis
 
 class InfoDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger by Logger()
+    private val logger = logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/InfoDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/InfoDAO.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.data
 
+import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
-import org.slf4j.LoggerFactory
 import redis.clients.jedis.Jedis
 
 class InfoDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger = LoggerFactory.getLogger(InfoDAO::class.java)
+    private val logger by Logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/NightscoutDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/NightscoutDAO.kt
@@ -1,7 +1,7 @@
 package com.dongtronic.diabot.data
 
-import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
+import com.dongtronic.diabot.util.logger
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.User
 import redis.clients.jedis.Jedis
@@ -9,7 +9,7 @@ import java.util.*
 
 class NightscoutDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger by Logger()
+    private val logger = logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/NightscoutDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/NightscoutDAO.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.data
 
+import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.User
-import org.slf4j.LoggerFactory
 import redis.clients.jedis.Jedis
 import java.util.*
 
 class NightscoutDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger = LoggerFactory.getLogger(NightscoutDAO::class.java)
+    private val logger by Logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -1,9 +1,6 @@
 package com.dongtronic.diabot.data
 
-import com.dongtronic.diabot.util.MongoDB
-import com.dongtronic.diabot.util.findMany
-import com.dongtronic.diabot.util.findOne
-import com.dongtronic.diabot.util.findOneRandom
+import com.dongtronic.diabot.util.*
 import com.mongodb.client.model.Filters.and
 import com.mongodb.client.model.FindOneAndUpdateOptions
 import com.mongodb.client.model.IndexOptions
@@ -17,7 +14,6 @@ import org.bson.conversions.Bson
 import org.litote.kmongo.descending
 import org.litote.kmongo.eq
 import org.litote.kmongo.reactivestreams.updateOne
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
@@ -30,7 +26,7 @@ class QuoteDAO private constructor() {
             = MongoDB.getInstance().database.getCollection("quote-index", QuoteIndexDTO::class.java)
 
     private val scheduler = Schedulers.boundedElastic()
-    private val logger = LoggerFactory.getLogger(QuoteDAO::class.java)
+    private val logger by Logger()
     val enabledGuilds = System.getenv().getOrDefault("QUOTE_ENABLE_GUILDS", "").split(",")
     val maxQuotes = System.getenv().getOrDefault("QUOTE_MAX", "5000").toIntOrNull() ?: 5000
 

--- a/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/QuoteDAO.kt
@@ -26,7 +26,7 @@ class QuoteDAO private constructor() {
             = MongoDB.getInstance().database.getCollection("quote-index", QuoteIndexDTO::class.java)
 
     private val scheduler = Schedulers.boundedElastic()
-    private val logger by Logger()
+    private val logger = logger()
     val enabledGuilds = System.getenv().getOrDefault("QUOTE_ENABLE_GUILDS", "").split(",")
     val maxQuotes = System.getenv().getOrDefault("QUOTE_MAX", "5000").toIntOrNull() ?: 5000
 

--- a/src/main/java/com/dongtronic/diabot/data/RewardDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/RewardDAO.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.data
 
-import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
+import com.dongtronic.diabot.util.logger
 import redis.clients.jedis.Jedis
 
 class RewardDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger by Logger()
+    private val logger = logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/RewardDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/RewardDAO.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.data
 
+import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
-import org.slf4j.LoggerFactory
 import redis.clients.jedis.Jedis
 
 class RewardDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger = LoggerFactory.getLogger(RewardDAO::class.java)
+    private val logger by Logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/RulesDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/RulesDAO.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.data
 
+import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
-import org.slf4j.LoggerFactory
 import redis.clients.jedis.Jedis
 
 class RulesDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger = LoggerFactory.getLogger(RulesDAO::class.java)
+    private val logger by Logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/data/RulesDAO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/RulesDAO.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.data
 
-import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.RedisKeyFormats
+import com.dongtronic.diabot.util.logger
 import redis.clients.jedis.Jedis
 
 class RulesDAO private constructor() {
     private var jedis: Jedis? = null
-    private val logger by Logger()
+    private val logger = logger()
 
 
     init {

--- a/src/main/java/com/dongtronic/diabot/logic/diabetes/A1cConverter.kt
+++ b/src/main/java/com/dongtronic/diabot/logic/diabetes/A1cConverter.kt
@@ -3,14 +3,14 @@ package com.dongtronic.diabot.logic.diabetes
 import com.dongtronic.diabot.data.A1cDTO
 import com.dongtronic.diabot.data.ConversionDTO
 import com.dongtronic.diabot.exceptions.UnknownUnitException
-import org.slf4j.LoggerFactory
+import com.dongtronic.diabot.util.Logger
 
 /**
  * A1c conversion logic
  */
 object A1cConverter {
 
-    private val logger = LoggerFactory.getLogger(A1cConverter::class.java)
+    private val logger by Logger()
 
     @Throws(UnknownUnitException::class)
     fun estimateA1c(originalValue: String, unit: String?): A1cDTO {

--- a/src/main/java/com/dongtronic/diabot/logic/diabetes/A1cConverter.kt
+++ b/src/main/java/com/dongtronic/diabot/logic/diabetes/A1cConverter.kt
@@ -3,14 +3,14 @@ package com.dongtronic.diabot.logic.diabetes
 import com.dongtronic.diabot.data.A1cDTO
 import com.dongtronic.diabot.data.ConversionDTO
 import com.dongtronic.diabot.exceptions.UnknownUnitException
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 
 /**
  * A1c conversion logic
  */
 object A1cConverter {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     @Throws(UnknownUnitException::class)
     fun estimateA1c(originalValue: String, unit: String?): A1cDTO {

--- a/src/main/java/com/dongtronic/diabot/logic/nutrition/NutritionixCommunicator.kt
+++ b/src/main/java/com/dongtronic/diabot/logic/nutrition/NutritionixCommunicator.kt
@@ -3,7 +3,7 @@ package com.dongtronic.diabot.logic.nutrition
 import com.dongtronic.diabot.data.nutrition.NutritionRequestDTO
 import com.dongtronic.diabot.data.nutrition.NutritionResponseDTO
 import com.dongtronic.diabot.exceptions.RequestStatusException
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.http.client.methods.RequestBuilder
 import org.apache.http.entity.StringEntity
@@ -15,7 +15,7 @@ object NutritionixCommunicator {
     private val secret = System.getenv("nutritionixsecret")
     private const val baseUrl = "https://trackapi.nutritionix.com/v2"
     private val mapper = ObjectMapper()
-    private val logger by Logger()
+    private val logger = logger()
 
     public fun getNutritionInfo(input: String): NutritionResponseDTO {
         val url = "$baseUrl/natural/nutrients"

--- a/src/main/java/com/dongtronic/diabot/logic/nutrition/NutritionixCommunicator.kt
+++ b/src/main/java/com/dongtronic/diabot/logic/nutrition/NutritionixCommunicator.kt
@@ -3,19 +3,19 @@ package com.dongtronic.diabot.logic.nutrition
 import com.dongtronic.diabot.data.nutrition.NutritionRequestDTO
 import com.dongtronic.diabot.data.nutrition.NutritionResponseDTO
 import com.dongtronic.diabot.exceptions.RequestStatusException
+import com.dongtronic.diabot.util.Logger
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.http.client.methods.RequestBuilder
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.util.EntityUtils
-import org.slf4j.LoggerFactory
 
 object NutritionixCommunicator {
     private val appid = System.getenv("nutritionixappid")
     private val secret = System.getenv("nutritionixsecret")
     private const val baseUrl = "https://trackapi.nutritionix.com/v2"
     private val mapper = ObjectMapper()
-    private val logger = LoggerFactory.getLogger(NutritionixCommunicator::class.java)
+    private val logger by Logger()
 
     public fun getNutritionInfo(input: String): NutritionResponseDTO {
         val url = "$baseUrl/natural/nutrients"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleCommand.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.commands
 
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class SampleCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "test"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleCommand.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.commands
 
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
 
 class SampleCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(SampleCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "test"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleSubCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleSubCommand.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.platforms.discord.commands
 
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class SampleSubCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "sub"
@@ -29,7 +29,7 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiscordCo
     }
 
     class SampleListSubCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-        private val logger by Logger()
+        private val logger = logger()
 
         init {
             this.name = "list"
@@ -44,7 +44,7 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiscordCo
     }
 
     class SampleAddSubCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-        private val logger by Logger()
+        private val logger = logger()
 
         init {
             this.name = "add"
@@ -59,7 +59,7 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiscordCo
     }
 
     class SampleDeleteSubCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-        private val logger by Logger()
+        private val logger = logger()
 
         init {
             this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleSubCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleSubCommand.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.platforms.discord.commands
 
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class SampleSubCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(SampleSubCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "sub"
@@ -29,7 +29,7 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiscordCo
     }
 
     class SampleListSubCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-        private val logger = LoggerFactory.getLogger(SampleListSubCommand::class.java)
+        private val logger by Logger()
 
         init {
             this.name = "list"
@@ -44,7 +44,7 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiscordCo
     }
 
     class SampleAddSubCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-        private val logger = LoggerFactory.getLogger(SampleAddSubCommand::class.java)
+        private val logger by Logger()
 
         init {
             this.name = "add"
@@ -59,7 +59,7 @@ class SampleSubCommand(category: Command.Category, parent: Command?) : DiscordCo
     }
 
     class SampleDeleteSubCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-        private val logger = LoggerFactory.getLogger(SampleDeleteSubCommand::class.java)
+        private val logger by Logger()
 
         init {
             this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminAnnounceCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminAnnounceCommand.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class AdminAnnounceCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "announce"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminAnnounceCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminAnnounceCommand.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class AdminAnnounceCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminAnnounceCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "announce"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminChannelsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminChannelsCommand.kt
@@ -4,14 +4,14 @@ import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.channels.AdminChannelAddCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.channels.AdminChannelDeleteCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.channels.AdminChannelListCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
 
 class AdminChannelsCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminChannelsCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "channels"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminChannelsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminChannelsCommand.kt
@@ -4,14 +4,14 @@ import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.channels.AdminChannelAddCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.channels.AdminChannelDeleteCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.channels.AdminChannelListCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class AdminChannelsCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "channels"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
 
 class AdminCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger = LoggerFactory.getLogger(AdminCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "admin"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class AdminCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "admin"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminRewardsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminRewardsCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.rewards.*
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class AdminRewardsCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "rewards"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminRewardsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminRewardsCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.rewards.*
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
 
 class AdminRewardsCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminRewardsCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "rewards"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminRulesCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminRulesCommand.kt
@@ -5,13 +5,13 @@ import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUser
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernameEnableCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernameHintCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernamePatternCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class AdminRulesCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "rules"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminRulesCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminRulesCommand.kt
@@ -5,13 +5,13 @@ import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUser
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernameEnableCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernameHintCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernamePatternCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class AdminRulesCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminRulesCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "rules"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminUsernameCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminUsernameCommand.kt
@@ -5,13 +5,13 @@ import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUser
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernameEnableCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernameHintCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernamePatternCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class AdminUsernameCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminUsernameCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "usernames"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminUsernameCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminUsernameCommand.kt
@@ -5,13 +5,13 @@ import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUser
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernameEnableCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernameHintCommand
 import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUsernamePatternCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class AdminUsernameCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "usernames"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/OwnerCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/OwnerCommand.kt
@@ -1,9 +1,7 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class OwnerCommand(category: Category) : DiscordCommand(category, null) {
 

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/ShutdownCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/ShutdownCommand.kt
@@ -1,7 +1,7 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
@@ -35,7 +35,7 @@ class ShutdownCommand(category: Command.Category) : DiscordCommand(category, nul
 
     companion object {
 
-        private val logger by Logger()
+        private val logger = logger()
     }
 
 }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/ShutdownCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/ShutdownCommand.kt
@@ -1,9 +1,9 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 /**
  * @author John Grosh (jagrosh)
@@ -35,7 +35,7 @@ class ShutdownCommand(category: Command.Category) : DiscordCommand(category, nul
 
     companion object {
 
-        private val logger = LoggerFactory.getLogger(ShutdownCommand::class.java)
+        private val logger by Logger()
     }
 
 }

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelAddCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.channels
 
 import com.dongtronic.diabot.data.AdminDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class AdminChannelAddCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "add"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelAddCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.channels
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class AdminChannelAddCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-    private val logger = LoggerFactory.getLogger(AdminChannelAddCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "add"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelDeleteCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.channels
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class AdminChannelDeleteCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-    private val logger = LoggerFactory.getLogger(AdminChannelDeleteCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelDeleteCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.channels
 
 import com.dongtronic.diabot.data.AdminDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class AdminChannelDeleteCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelListCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.channels
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
-import org.slf4j.LoggerFactory
 
 class AdminChannelListCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-    private val logger = LoggerFactory.getLogger(AdminChannelListCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "list"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/channels/AdminChannelListCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.channels
 
 import com.dongtronic.diabot.data.AdminDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 
 class AdminChannelListCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "list"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardAddCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class AdminRewardAddCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "add"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardAddCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class AdminRewardAddCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminRewardAddCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "add"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardDeleteCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class AdminRewardDeleteCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardDeleteCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class AdminRewardDeleteCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminRewardDeleteCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListCommand.kt
@@ -3,7 +3,7 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.RoleUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
@@ -12,7 +12,7 @@ import java.util.*
 
 class AdminRewardListCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "list"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListCommand.kt
@@ -1,18 +1,18 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.RoleUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Role
-import org.slf4j.LoggerFactory
 import java.util.*
 
 class AdminRewardListCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminRewardListCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "list"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListOptoutsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListOptoutsCommand.kt
@@ -1,16 +1,16 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.CommandUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
-import org.slf4j.LoggerFactory
 
 class AdminRewardListOptoutsCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminRewardListOptoutsCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "listoptouts"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListOptoutsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListOptoutsCommand.kt
@@ -3,14 +3,14 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.CommandUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 
 class AdminRewardListOptoutsCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "listoptouts"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardOptinCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardOptinCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class AdminRewardOptinCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminRewardOptinCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "optin"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardOptinCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardOptinCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class AdminRewardOptinCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "optin"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardOptoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardOptoutCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class AdminRewardOptoutCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "optout"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardOptoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardOptoutCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.rewards
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class AdminRewardOptoutCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminRewardOptoutCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "optout"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameDisableCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameDisableCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.username
 
 import com.dongtronic.diabot.data.AdminDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class AdminUsernameDisableCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "disable"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameDisableCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameDisableCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.username
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class AdminUsernameDisableCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminUsernameDisableCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "disable"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameEnableCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameEnableCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.username
 
 import com.dongtronic.diabot.data.AdminDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class AdminUsernameEnableCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "enable"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameEnableCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameEnableCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.username
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class AdminUsernameEnableCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminUsernameEnableCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "enable"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameHintCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameHintCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.username
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class AdminUsernameHintCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminUsernameHintCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "hint"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameHintCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameHintCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.username
 
 import com.dongtronic.diabot.data.AdminDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class AdminUsernameHintCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "hint"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernamePatternCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernamePatternCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.admin.username
 
 import com.dongtronic.diabot.data.AdminDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class AdminUsernamePatternCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "pattern"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernamePatternCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernamePatternCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.admin.username
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class AdminUsernamePatternCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(AdminUsernamePatternCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "pattern"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConvertCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConvertCommand.kt
@@ -5,13 +5,13 @@ import com.dongtronic.diabot.exceptions.UnknownUnitException
 import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
 import com.dongtronic.diabot.logic.diabetes.GlucoseUnit
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class ConvertCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "convert"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConvertCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConvertCommand.kt
@@ -1,17 +1,17 @@
 package com.dongtronic.diabot.platforms.discord.commands.diabetes
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
-import com.dongtronic.diabot.logic.diabetes.GlucoseUnit
 import com.dongtronic.diabot.data.ConversionDTO
 import com.dongtronic.diabot.exceptions.UnknownUnitException
+import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
+import com.dongtronic.diabot.logic.diabetes.GlucoseUnit
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class ConvertCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger = LoggerFactory.getLogger(ConvertCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "convert"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/EstimationCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/EstimationCommand.kt
@@ -1,18 +1,18 @@
 package com.dongtronic.diabot.platforms.discord.commands.diabetes
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.data.A1cDTO
+import com.dongtronic.diabot.exceptions.UnknownUnitException
 import com.dongtronic.diabot.logic.diabetes.A1cConverter
 import com.dongtronic.diabot.logic.diabetes.GlucoseUnit.MGDL
 import com.dongtronic.diabot.logic.diabetes.GlucoseUnit.MMOL
-import com.dongtronic.diabot.data.A1cDTO
-import com.dongtronic.diabot.exceptions.UnknownUnitException
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class EstimationCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger = LoggerFactory.getLogger(EstimationCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "estimate"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/EstimationCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/EstimationCommand.kt
@@ -6,13 +6,13 @@ import com.dongtronic.diabot.logic.diabetes.A1cConverter
 import com.dongtronic.diabot.logic.diabetes.GlucoseUnit.MGDL
 import com.dongtronic.diabot.logic.diabetes.GlucoseUnit.MMOL
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class EstimationCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "estimate"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.info
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.InfoDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
-import org.slf4j.LoggerFactory
 
 class InfoCommand(category: Category) : DiscordCommand(category, null) {
 
-    private val logger = LoggerFactory.getLogger(InfoCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "info"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.info
 
 import com.dongtronic.diabot.data.InfoDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 
 class InfoCommand(category: Category) : DiscordCommand(category, null) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "info"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoDeleteCommand.kt
@@ -2,13 +2,13 @@ package com.dongtronic.diabot.platforms.discord.commands.info
 
 import com.dongtronic.diabot.data.InfoDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class InfoDeleteCommand(category: Command.Category, parent: Command) : DiscordCommand(category, parent) {
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoDeleteCommand.kt
@@ -1,16 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.info
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.InfoDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
-import java.lang.Exception
 
 class InfoDeleteCommand(category: Command.Category, parent: Command) : DiscordCommand(category, parent) {
-
-    private val logger = LoggerFactory.getLogger(InfoDeleteCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoListCommand.kt
@@ -1,17 +1,16 @@
 package com.dongtronic.diabot.platforms.discord.commands.info
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.InfoDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
-import org.slf4j.LoggerFactory
-import java.lang.Exception
 
 class InfoListCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(InfoListCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "list"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoListCommand.kt
@@ -2,7 +2,7 @@ package com.dongtronic.diabot.platforms.discord.commands.info
 
 import com.dongtronic.diabot.data.InfoDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
@@ -10,7 +10,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 
 class InfoListCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "list"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoSetCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoSetCommand.kt
@@ -1,16 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.info
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.InfoDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
-import java.lang.Exception
 
 class InfoSetCommand(category: Command.Category, parent: Command) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(InfoSetCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "set"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoSetCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/InfoSetCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.info
 
 import com.dongtronic.diabot.data.InfoDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class InfoSetCommand(category: Command.Category, parent: Command) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "set"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/DisclaimerCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/DisclaimerCommand.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.commands.misc
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class DisclaimerCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "disclaimer"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/DisclaimerCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/DisclaimerCommand.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.commands.misc
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class DisclaimerCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger = LoggerFactory.getLogger(DisclaimerCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "disclaimer"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/NutritionCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/NutritionCommand.kt
@@ -3,13 +3,13 @@ package com.dongtronic.diabot.platforms.discord.commands.misc
 import com.dongtronic.diabot.exceptions.RequestStatusException
 import com.dongtronic.diabot.logic.nutrition.NutritionixCommunicator
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
-import org.slf4j.LoggerFactory
 
 class NutritionCommand(category: Category) : DiscordCommand(category, null) {
 
-    val logger = LoggerFactory.getLogger(NutritionCommand::class.java)
+    val logger by Logger()
 
     init {
         this.name = "nutrition"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/NutritionCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/NutritionCommand.kt
@@ -3,13 +3,13 @@ package com.dongtronic.diabot.platforms.discord.commands.misc
 import com.dongtronic.diabot.exceptions.RequestStatusException
 import com.dongtronic.diabot.logic.nutrition.NutritionixCommunicator
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 
 class NutritionCommand(category: Category) : DiscordCommand(category, null) {
 
-    val logger by Logger()
+    val logger = logger()
 
     init {
         this.name = "nutrition"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class NightscoutAdminCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "nightscoutadmin"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
 
 class NightscoutAdminCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutAdminCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "nightscoutadmin"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminDeleteCommand.kt
@@ -3,14 +3,14 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class NightscoutAdminDeleteCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminDeleteCommand.kt
@@ -1,16 +1,16 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class NightscoutAdminDeleteCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutAdminDeleteCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSetCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSetCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class NightscoutAdminSetCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutAdminSetCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "set"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSetCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSetCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class NightscoutAdminSetCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "set"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleAddCommand.kt
@@ -1,16 +1,16 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.CommandUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class NightscoutAdminSimpleAddCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutAdminSimpleAddCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "add"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleAddCommand.kt
@@ -3,14 +3,14 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.CommandUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class NightscoutAdminSimpleAddCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "add"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
 
 class NightscoutAdminSimpleCommand(category: Command.Category, parent: DiscordCommand) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutAdminSimpleCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "simple"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleCommand.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class NightscoutAdminSimpleCommand(category: Command.Category, parent: DiscordCommand) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "simple"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleDeleteCommand.kt
@@ -1,16 +1,16 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.CommandUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
-import org.slf4j.LoggerFactory
 
 class NightscoutAdminSimpleDeleteCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutAdminSimpleDeleteCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleDeleteCommand.kt
@@ -3,14 +3,14 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.CommandUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import org.apache.commons.lang3.StringUtils
 
 class NightscoutAdminSimpleDeleteCommand(category: Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleListCommand.kt
@@ -1,16 +1,16 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.CommandUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
-import org.slf4j.LoggerFactory
 
 class NightscoutAdminSimpleListCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutAdminSimpleListCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "list"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleListCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSimpleListCommand.kt
@@ -3,14 +3,14 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.CommandUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 
 class NightscoutAdminSimpleListCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "list"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
@@ -11,6 +11,7 @@ import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
 import com.dongtronic.diabot.util.LimitedSystemDnsResolver
+import com.dongtronic.diabot.util.Logger
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.stream.MalformedJsonException
@@ -28,7 +29,6 @@ import org.apache.http.client.methods.RequestBuilder
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.message.BasicNameValuePair
 import org.apache.http.util.EntityUtils
-import org.slf4j.LoggerFactory
 import java.awt.Color
 import java.io.IOException
 import java.net.UnknownHostException
@@ -38,7 +38,7 @@ import java.time.ZonedDateTime
 
 class NightscoutCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutCommand::class.java)
+    private val logger by Logger()
     private val httpClient: HttpClient
     private val requestConfig: RequestConfig
     private val trendArrows: Array<String> = arrayOf("", "↟", "↑", "↗", "→", "↘", "↓", "↡", "↮", "↺")

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
@@ -11,7 +11,7 @@ import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
 import com.dongtronic.diabot.util.LimitedSystemDnsResolver
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.stream.MalformedJsonException
@@ -38,7 +38,7 @@ import java.time.ZonedDateTime
 
 class NightscoutCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger by Logger()
+    private val logger = logger()
     private val httpClient: HttpClient
     private val requestConfig: RequestConfig
     private val trendArrows: Array<String> = arrayOf("", "↟", "↑", "↗", "→", "↘", "↓", "↡", "↮", "↺")

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutDeleteCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
 
 class NightscoutDeleteCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutDeleteCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
-import org.slf4j.LoggerFactory
 
 class NightscoutDeleteCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutDeleteCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutPublicCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutPublicCommand.kt
@@ -3,13 +3,13 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class NightscoutPublicCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "public"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutPublicCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutPublicCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class NightscoutPublicCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutPublicCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "public"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetDisplayCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetDisplayCommand.kt
@@ -3,7 +3,7 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
@@ -14,7 +14,7 @@ class NightscoutSetDisplayCommand(category: Command.Category, parent: Command?) 
         val validOptions = enabledOptions.plus(arrayOf("simple", "none"))
     }
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "display"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetDisplayCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetDisplayCommand.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
-import org.slf4j.LoggerFactory
 
 class NightscoutSetDisplayCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
     companion object {
@@ -14,7 +14,7 @@ class NightscoutSetDisplayCommand(category: Command.Category, parent: Command?) 
         val validOptions = enabledOptions.plus(arrayOf("simple", "none"))
     }
 
-    private val logger = LoggerFactory.getLogger(NightscoutSetDisplayCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "display"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetTokenCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetTokenCommand.kt
@@ -2,7 +2,7 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
@@ -10,7 +10,7 @@ import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
 
 class NightscoutSetTokenCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "token"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetTokenCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetTokenCommand.kt
@@ -1,16 +1,16 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.NightscoutDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-import org.slf4j.LoggerFactory
 
 class NightscoutSetTokenCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutSetTokenCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "token"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetUrlCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetUrlCommand.kt
@@ -2,15 +2,15 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-import org.slf4j.LoggerFactory
 
 class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(NightscoutSetUrlCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "set"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetUrlCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetUrlCommand.kt
@@ -2,7 +2,7 @@ package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.data.NightscoutDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.User
@@ -10,7 +10,7 @@ import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
 
 class NightscoutSetUrlCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "set"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -3,13 +3,13 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class QuoteAddCommand(category: Category, parent: QuoteCommand) : DiscordCommand(category, parent) {
     private val mentionsRegex = parent.mentionsRegex
     private val quoteRegex = Regex("\"(?<message>[\\s\\S]*)\" ?- ?(?<author>.*[^\\s])")
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "add"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -3,13 +3,13 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class QuoteAddCommand(category: Category, parent: QuoteCommand) : DiscordCommand(category, parent) {
     private val mentionsRegex = parent.mentionsRegex
     private val quoteRegex = Regex("\"(?<message>[\\s\\S]*)\" ?- ?(?<author>.*[^\\s])")
-    private val logger = LoggerFactory.getLogger(QuoteAddCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "add"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -3,19 +3,19 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
 import org.bson.conversions.Bson
 import org.litote.kmongo.eq
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import java.time.Instant
 
 class QuoteCommand(category: Category) : DiscordCommand(category, null) {
     val mentionsRegex = Regex("<@!(?<uid>\\d+)>")
     private val discordMessageLink = "https://discordapp.com/channels/{{guild}}/{{channel}}/{{message}}"
-    private val logger = LoggerFactory.getLogger(QuoteCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "quote"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -3,7 +3,7 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -15,7 +15,7 @@ import java.time.Instant
 class QuoteCommand(category: Category) : DiscordCommand(category, null) {
     val mentionsRegex = Regex("<@!(?<uid>\\d+)>")
     private val discordMessageLink = "https://discordapp.com/channels/{{guild}}/{{channel}}/{{message}}"
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "quote"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -2,16 +2,16 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import com.mongodb.client.result.DeleteResult
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
 class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
-    private val logger = LoggerFactory.getLogger(QuoteDeleteCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -2,7 +2,7 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import com.mongodb.client.result.DeleteResult
@@ -11,7 +11,7 @@ import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
 class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "delete"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
-import org.slf4j.LoggerFactory
 
 class QuoteEditCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
     private val quoteRegex = Regex("(?<qid>.*) \"(?<message>[\\s\\S]*)\" ?- ?(?<author>.*[^\\s])")
-    private val logger = LoggerFactory.getLogger(QuoteEditCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "edit"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteEditCommand.kt
@@ -2,14 +2,14 @@ package com.dongtronic.diabot.platforms.discord.commands.quote
 
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
 
 class QuoteEditCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
     private val quoteRegex = Regex("(?<qid>.*) \"(?<message>[\\s\\S]*)\" ?- ?(?<author>.*[^\\s])")
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "edit"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteImportCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteImportCommand.kt
@@ -4,7 +4,7 @@ import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.exceptions.RequestStatusException
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 class QuoteImportCommand(category: Category, parent: QuoteCommand) : DiscordCommand(category, parent), EventListener {
     private val mapper = jacksonObjectMapper()
-    private val logger by Logger()
+    private val logger = logger()
     private val pendingRequests = mutableSetOf<User>()
     private var guildMessages = DirectProcessor.create<GuildMessageReceivedEvent>()
     private var eventListening = false

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteImportCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteImportCommand.kt
@@ -4,6 +4,7 @@ import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.exceptions.RequestStatusException
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -19,7 +20,6 @@ import net.dv8tion.jda.internal.requests.Requester
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.litote.kmongo.eq
-import org.slf4j.LoggerFactory
 import reactor.core.Exceptions
 import reactor.core.publisher.DirectProcessor
 import reactor.core.publisher.Mono
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 class QuoteImportCommand(category: Category, parent: QuoteCommand) : DiscordCommand(category, parent), EventListener {
     private val mapper = jacksonObjectMapper()
-    private val logger = LoggerFactory.getLogger(QuoteImportCommand::class.java)
+    private val logger by Logger()
     private val pendingRequests = mutableSetOf<User>()
     private var guildMessages = DirectProcessor.create<GuildMessageReceivedEvent>()
     private var eventListening = false

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsCommand.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.commands.rewards
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class RewardsCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger = LoggerFactory.getLogger(RewardsCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "rewards"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsCommand.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.commands.rewards
 
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class RewardsCommand(category: Command.Category) : DiscordCommand(category, null) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "rewards"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsOptInCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsOptInCommand.kt
@@ -3,13 +3,13 @@ package com.dongtronic.diabot.platforms.discord.commands.rewards
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class RewardsOptInCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "optin"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsOptInCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsOptInCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.rewards
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class RewardsOptInCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(RewardsOptInCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "optin"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsOptOutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsOptOutCommand.kt
@@ -3,13 +3,13 @@ package com.dongtronic.diabot.platforms.discord.commands.rewards
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 
 class RewardsOptOutCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
 
-    private val logger by Logger()
+    private val logger = logger()
 
     init {
         this.name = "optout"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsOptOutCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/rewards/RewardsOptOutCommand.kt
@@ -1,15 +1,15 @@
 package com.dongtronic.diabot.platforms.discord.commands.rewards
 
-import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.data.RewardDAO
+import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.utils.NicknameUtils
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
-import org.slf4j.LoggerFactory
 
 class RewardsOptOutCommand(category: Category, parent: Command) : DiscordCommand(category, parent) {
 
-    private val logger = LoggerFactory.getLogger(RewardsOptOutCommand::class.java)
+    private val logger by Logger()
 
     init {
         this.name = "optout"

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -4,13 +4,13 @@ import com.dongtronic.diabot.data.ConversionDTO
 import com.dongtronic.diabot.exceptions.UnknownUnitException
 import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
 import com.dongtronic.diabot.logic.diabetes.GlucoseUnit
-import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.Patterns
+import com.dongtronic.diabot.util.logger
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 
 class ConversionListener : ListenerAdapter() {
-    private val logger by Logger()
+    private val logger = logger()
 
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
         if (event.author.isBot) return

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -1,16 +1,16 @@
 package com.dongtronic.diabot.platforms.discord.listeners
 
-import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
-import com.dongtronic.diabot.logic.diabetes.GlucoseUnit
 import com.dongtronic.diabot.data.ConversionDTO
 import com.dongtronic.diabot.exceptions.UnknownUnitException
+import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
+import com.dongtronic.diabot.logic.diabetes.GlucoseUnit
+import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.Patterns
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
-import org.slf4j.LoggerFactory
 
 class ConversionListener : ListenerAdapter() {
-    private val logger = LoggerFactory.getLogger(ConversionListener::class.java)
+    private val logger by Logger()
 
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
         if (event.author.isBot) return

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/HelpListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/HelpListener.kt
@@ -2,6 +2,7 @@ package com.dongtronic.diabot.platforms.discord.listeners
 
 import com.dongtronic.diabot.exceptions.NoCommandFoundException
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
@@ -11,7 +12,6 @@ import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.exceptions.ErrorResponseException
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
 import net.dv8tion.jda.api.requests.ErrorResponse
-import org.slf4j.LoggerFactory
 import java.awt.Color
 import java.util.*
 import java.util.concurrent.CompletableFuture
@@ -19,7 +19,7 @@ import java.util.function.Consumer
 import kotlin.collections.ArrayList
 
 class HelpListener : Consumer<CommandEvent> {
-    private val logger = LoggerFactory.getLogger(HelpListener::class.java)
+    private val logger by Logger()
 
     /**
      * Executed when the attempt to send a DM to a user fails

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/HelpListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/HelpListener.kt
@@ -2,7 +2,7 @@ package com.dongtronic.diabot.platforms.discord.listeners
 
 import com.dongtronic.diabot.exceptions.NoCommandFoundException
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.EmbedBuilder
@@ -19,7 +19,7 @@ import java.util.function.Consumer
 import kotlin.collections.ArrayList
 
 class HelpListener : Consumer<CommandEvent> {
-    private val logger by Logger()
+    private val logger = logger()
 
     /**
      * Executed when the attempt to send a DM to a user fails

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/OhNoListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/OhNoListener.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.listeners
 
+import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.Patterns
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
-import org.slf4j.LoggerFactory
 import java.util.*
 
 class OhNoListener : ListenerAdapter() {
-    private val logger = LoggerFactory.getLogger(OhNoListener::class.java)
+    private val logger by Logger()
 
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
         if (event.author.isBot) return

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/OhNoListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/OhNoListener.kt
@@ -1,13 +1,13 @@
 package com.dongtronic.diabot.platforms.discord.listeners
 
-import com.dongtronic.diabot.util.Logger
 import com.dongtronic.diabot.util.Patterns
+import com.dongtronic.diabot.util.logger
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import java.util.*
 
 class OhNoListener : ListenerAdapter() {
-    private val logger by Logger()
+    private val logger = logger()
 
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
         if (event.author.isBot) return

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -3,6 +3,7 @@ package com.dongtronic.diabot.platforms.discord.listeners
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.platforms.discord.commands.quote.QuoteCommand
+import com.dongtronic.diabot.util.Logger
 import com.jagrosh.jdautilities.command.CommandClient
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.Message
@@ -10,7 +11,6 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionAddEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import org.litote.kmongo.eq
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 import java.util.function.Consumer
@@ -19,7 +19,7 @@ class QuoteListener(private val client: CommandClient) : ListenerAdapter() {
     private val quoteCommand: QuoteCommand = client.commands.filterIsInstance(QuoteCommand::class.java).first()
     // https://emojiguide.org/speech-balloon
     private val speechEmoji = "U+1f4ac"
-    private val logger = LoggerFactory.getLogger(QuoteListener::class.java)
+    private val logger by Logger()
 
     override fun onGuildMessageReactionAdd(event: GuildMessageReactionAddEvent) {
         if (event.user.isBot) return

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -3,7 +3,7 @@ package com.dongtronic.diabot.platforms.discord.listeners
 import com.dongtronic.diabot.data.QuoteDAO
 import com.dongtronic.diabot.data.QuoteDTO
 import com.dongtronic.diabot.platforms.discord.commands.quote.QuoteCommand
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.CommandClient
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.Message
@@ -19,7 +19,7 @@ class QuoteListener(private val client: CommandClient) : ListenerAdapter() {
     private val quoteCommand: QuoteCommand = client.commands.filterIsInstance(QuoteCommand::class.java).first()
     // https://emojiguide.org/speech-balloon
     private val speechEmoji = "U+1f4ac"
-    private val logger by Logger()
+    private val logger = logger()
 
     override fun onGuildMessageReactionAdd(event: GuildMessageReactionAddEvent) {
         if (event.user.isBot) return

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/RewardListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/RewardListener.kt
@@ -2,12 +2,12 @@ package com.dongtronic.diabot.platforms.discord.listeners
 
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.utils.RoleUtils
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 
 class RewardListener : ListenerAdapter() {
-    private val logger by Logger()
+    private val logger = logger()
 
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
         if (event.author.isBot) return

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/RewardListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/RewardListener.kt
@@ -2,12 +2,12 @@ package com.dongtronic.diabot.platforms.discord.listeners
 
 import com.dongtronic.diabot.data.RewardDAO
 import com.dongtronic.diabot.platforms.discord.utils.RoleUtils
+import com.dongtronic.diabot.util.Logger
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
-import org.slf4j.LoggerFactory
 
 class RewardListener : ListenerAdapter() {
-    private val logger = LoggerFactory.getLogger(RewardListener::class.java)
+    private val logger by Logger()
 
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
         if (event.author.isBot) return

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/UsernameEnforcementListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/UsernameEnforcementListener.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.listeners
 
 import com.dongtronic.diabot.data.AdminDAO
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import net.dv8tion.jda.api.events.guild.member.GenericGuildMemberEvent
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 
 class UsernameEnforcementListener : ListenerAdapter() {
-    private val logger by Logger()
+    private val logger = logger()
 
     override fun onGuildMemberUpdateNickname(event: GuildMemberUpdateNicknameEvent) {
         val prevNick = if (event.oldNickname.isNullOrEmpty()) event.user.name else event.oldNickname

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/UsernameEnforcementListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/UsernameEnforcementListener.kt
@@ -1,14 +1,14 @@
 package com.dongtronic.diabot.platforms.discord.listeners
 
 import com.dongtronic.diabot.data.AdminDAO
+import com.dongtronic.diabot.util.Logger
 import net.dv8tion.jda.api.events.guild.member.GenericGuildMemberEvent
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
-import org.slf4j.LoggerFactory
 
 class UsernameEnforcementListener : ListenerAdapter() {
-    private val logger = LoggerFactory.getLogger(UsernameEnforcementListener::class.java)
+    private val logger by Logger()
 
     override fun onGuildMemberUpdateNickname(event: GuildMemberUpdateNicknameEvent) {
         val prevNick = if (event.oldNickname.isNullOrEmpty()) event.user.name else event.oldNickname

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/utils/RoleUtils.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/utils/RoleUtils.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.platforms.discord.utils
 
-import com.dongtronic.diabot.util.Logger
+import com.dongtronic.diabot.util.logger
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Role
 import java.util.*
 
 object RoleUtils {
-    private val logger by Logger()
+    private val logger = logger()
 
     fun buildRewardsMap(potentialRewards: MutableList<String>?, guild: Guild): TreeMap<Role, MutableList<Role>> {
         val rewards: TreeMap<Role, MutableList<Role>> = TreeMap()

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/utils/RoleUtils.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/utils/RoleUtils.kt
@@ -1,12 +1,12 @@
 package com.dongtronic.diabot.platforms.discord.utils
 
+import com.dongtronic.diabot.util.Logger
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Role
-import org.slf4j.LoggerFactory
 import java.util.*
 
 object RoleUtils {
-    val logger = LoggerFactory.getLogger(RoleUtils.javaClass)!!
+    private val logger by Logger()
 
     fun buildRewardsMap(potentialRewards: MutableList<String>?, guild: Guild): TreeMap<Role, MutableList<Role>> {
         val rewards: TreeMap<Role, MutableList<Role>> = TreeMap()

--- a/src/main/java/com/dongtronic/diabot/util/Logger.kt
+++ b/src/main/java/com/dongtronic/diabot/util/Logger.kt
@@ -1,0 +1,16 @@
+package com.dongtronic.diabot.util
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+class Logger : ReadOnlyProperty<Any, Logger> {
+    private var logger: Logger? = null
+
+    override fun getValue(thisRef: Any, property: KProperty<*>): Logger {
+        if (logger == null)
+            logger = LoggerFactory.getLogger(thisRef.javaClass)
+        return logger!!
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/util/Logger.kt
+++ b/src/main/java/com/dongtronic/diabot/util/Logger.kt
@@ -2,15 +2,11 @@ package com.dongtronic.diabot.util
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import kotlin.properties.ReadOnlyProperty
-import kotlin.reflect.KProperty
 
-class Logger : ReadOnlyProperty<Any, Logger> {
-    private var logger: Logger? = null
-
-    override fun getValue(thisRef: Any, property: KProperty<*>): Logger {
-        if (logger == null)
-            logger = LoggerFactory.getLogger(thisRef.javaClass)
-        return logger!!
+inline fun <reified T> T.logger(): Logger {
+    if (T::class.isCompanion) {
+        return LoggerFactory.getLogger(T::class.java.enclosingClass)
     }
+
+    return LoggerFactory.getLogger(T::class.java)
 }

--- a/src/main/java/com/dongtronic/diabot/util/Logger.kt
+++ b/src/main/java/com/dongtronic/diabot/util/Logger.kt
@@ -3,8 +3,14 @@ package com.dongtronic.diabot.util
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+/**
+ * Creates a SLF4J logger named with the class which it is called from.
+ *
+ * @return A SLF4J [Logger] instance named with the calling class.
+ */
 inline fun <reified T> T.logger(): Logger {
     if (T::class.isCompanion) {
+        // grab the parent class if this class is a companion object
         return LoggerFactory.getLogger(T::class.java.enclosingClass)
     }
 


### PR DESCRIPTION
This is a very simple code cleanup PR which changes the initialization of loggers to `logger()` from `LoggerFactory.getLogger(MyClass::class.java)`. The functionality for this new function can be found in `src/main/java/com/dongtronic/diabot/util/Logger.kt`.

Imports have been shifted around as a result of IDEA's 'optimize import' feature, which I applied to fix the ordering of imports because I used 'Replace in Path' to change the following:
- `import org.slf4j.LoggerFactory`
  - to `import com.dongtronic.diabot.util.logger`
- `LoggerFactory.getLogger(***::class.java)`
  - to `logger()`