### PR TITLE
Quote fixes

### DIFF
--- a/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDTO.kt
+++ b/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDTO.kt
@@ -22,4 +22,32 @@ data class QuoteDTO(
         val message: String,
         val messageId: String,
         val time: Long = System.currentTimeMillis() / 1000
-)
+) {
+    /**
+     * Checks whether a quote has a message link associated with it.
+     * This is done by checking for the guild ID, channel ID, and message ID properties to have proper values.
+     *
+     * @return if the quote can have a link pointing to its original message
+     */
+    fun hasMessageLink(): Boolean {
+        return guildId != "0" && channelId != "0" && messageId != "0"
+    }
+
+    /**
+     * Creates a message link for a quote.
+     *
+     * @return a message link pointing to the quote, otherwise `null` if a link cannot be created
+     */
+    fun getMessageLink(): String? {
+        if (!hasMessageLink())
+            return null
+
+        return DISCORD_MESSAGE_LINK.replace("{guild}", guildId)
+                .replace("{channel}", channelId)
+                .replace("{message}", messageId)
+    }
+
+    companion object {
+        const val DISCORD_MESSAGE_LINK = "https://discordapp.com/channels/{guild}/{channel}/{message}"
+    }
+}

--- a/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -79,7 +79,7 @@ class QuoteListener(private val client: CommandClient) : ListenerAdapter() {
     override fun onMessageReceived(event: MessageReceivedEvent) {
         if (event.author.isBot || !event.isFromGuild) return
 
-        val msg = event.message.contentStripped
+        val msg = event.message.contentRaw
         if (msg.startsWith(".")) {
             val fullCommand = msg.substringAfter('.')
             // split the command name from the arguments (if any)


### PR DESCRIPTION
This fixes a few issues with quotes:
- Quote importing was broken if the quote IDs to import already existed in any guild
- Work around embed description exceeding the 2048 char limit when trying to grab quotes which are near 2000 characters long
- Don't treat `.quote` commands prefixed by formatting tags as quote commands
  - for example, `` `.quote` `` was treated as a command when it shouldn't be