### PR TITLE
Fix admin rewards listoptout help entry

### DIFF
--- a/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListOptoutsCommand.kt
+++ b/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/rewards/AdminRewardListOptoutsCommand.kt
@@ -14,7 +14,7 @@ class AdminRewardListOptoutsCommand(category: Command.Category, parent: Command?
 
     init {
         this.name = "listoptouts"
-        this.help = "Add role reward"
+        this.help = "List opted-out users"
         this.guildOnly = true
         this.aliases = arrayOf("lo")
     }


### PR DESCRIPTION
Corrects the listoptout help entry from a default copy-pasted value to the correct description