### PR TITLE
Fixed fatjar errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,10 @@ dependencies {
     compile 'commons-configuration:commons-configuration:1.6'
 
     // Networking
-    implementation 'com.squareup.okhttp3:okhttp:4.8.1'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
-    implementation 'com.jakewharton.retrofit:retrofit2-reactor-adapter:2.1.0'
+    compile 'com.squareup.okhttp3:okhttp:4.8.1'
+    compile 'com.squareup.retrofit2:retrofit:2.9.0'
+    compile 'com.squareup.retrofit2:converter-jackson:2.9.0'
+    compile 'com.jakewharton.retrofit:retrofit2-reactor-adapter:2.1.0'
 
     // Database
     compile 'redis.clients:jedis:3.3.0'


### PR DESCRIPTION
The updated okhttp and retrofit libraries weren't being included in the fatjar file after compilation. On line 72 in the `build.gradle` file it is set up to only copy dependencies using the `compile` keyword and not `implementation`. This PR is just a quick workaround which changes the `implementation`s to `compile`