### PR TITLE
Fix Heroku building

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
I believe this is needed to fix the builds failing (since we're now using Java 11). From https://devcenter.heroku.com/articles/java-support#specifying-a-java-version