### PR TITLE
Fix display name lookups

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/Extensions.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/Extensions.kt
@@ -9,11 +9,25 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
+/**
+ * Gets the command executor's display name.
+ *
+ * Note: this is a blocking call.
+ */
 val CommandEvent.authorName: String
-    get() = NicknameUtils.determineAuthorDisplayName(this)
+    get() = NicknameUtils.determineAuthorDisplayName(this).block()!!
 
+/**
+ * Gets the display name of a [User].
+ *
+ * Note: this is a blocking call.
+ *
+ * @receiver CommandEvent
+ * @param user The user to retrieve the display name of
+ * @return the display name of the given user
+ */
 fun CommandEvent.nameOf(user: User): String {
-    return NicknameUtils.determineDisplayName(this, user)
+    return NicknameUtils.determineDisplayName(this, user).block()!!
 }
 
 fun <T> RestAction<T>.submitMono(): Mono<T> {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutPublicCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutPublicCommand.kt
@@ -41,13 +41,14 @@ class NightscoutPublicCommand(category: Command.Category, parent: Command?) : Di
     }
 
     fun reply(event: CommandEvent, result: Mono<Boolean>) {
-        val authorNick = NicknameUtils.determineAuthorDisplayName(event)
-        result.subscribe({ public ->
-            val visibility = if (public) "public" else "private"
-            event.reply("Nightscout data for $authorNick set to **$visibility** in **${event.guild.name}**")
-        }, {
-            event.replyError("Nightscout data for $authorNick could not be changed in **${event.guild.name}**")
-            logger.warn("Could not change Nightscout privacy", it)
-        })
+        NicknameUtils.determineAuthorDisplayName(event).subscribe { authorNick ->
+            result.subscribe({ public ->
+                val visibility = if (public) "public" else "private"
+                event.reply("Nightscout data for $authorNick set to **$visibility** in **${event.guild.name}**")
+            }, {
+                event.replyError("Nightscout data for $authorNick could not be changed in **${event.guild.name}**")
+                logger.warn("Could not change Nightscout privacy", it)
+            })
+        }
     }
 }

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetDisplayCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutSetDisplayCommand.kt
@@ -29,7 +29,6 @@ class NightscoutSetDisplayCommand(category: Command.Category, parent: Command?) 
 
     override fun execute(event: CommandEvent) {
         val args = event.args.split("[\\s,]+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        val nickname = NicknameUtils.determineAuthorDisplayName(event)
 
         if (args.isEmpty()) {
             event.reply("Possible display options: ${formatOptions()}")
@@ -58,16 +57,18 @@ class NightscoutSetDisplayCommand(category: Command.Category, parent: Command?) 
             setNightscoutDisplay(event.author)
         }
 
-        updateDisplay.subscribe({ newOptions ->
-            if (newOptions.any { it == "reset" }) {
-                event.replySuccess("Reset Nightscout display options for $nickname")
-            } else {
-                event.replySuccess("Nightscout display options for $nickname set to: ${formatOptions(newOptions)}")
-            }
-        }, {
-            logger.warn("Error while setting NS display options", it)
-            event.replyError("Could not set Nightscout display options for $nickname")
-        })
+        NicknameUtils.determineAuthorDisplayName(event).subscribe { nickname ->
+            updateDisplay.subscribe({ newOptions ->
+                if (newOptions.any { it == "reset" }) {
+                    event.replySuccess("Reset Nightscout display options for $nickname")
+                } else {
+                    event.replySuccess("Nightscout display options for $nickname set to: ${formatOptions(newOptions)}")
+                }
+            }, {
+                logger.warn("Error while setting NS display options", it)
+                event.replyError("Could not set Nightscout display options for $nickname")
+            })
+        }
     }
 
     private fun setNightscoutDisplay(user: User, vararg options: String): Mono<List<String>> {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/utils/NicknameUtils.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/utils/NicknameUtils.kt
@@ -1,20 +1,27 @@
 package com.dongtronic.diabot.platforms.discord.utils
 
+import com.dongtronic.diabot.submitMono
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.entities.ChannelType
 import net.dv8tion.jda.api.entities.User
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
 
 object NicknameUtils {
 
-    fun determineAuthorDisplayName(event: CommandEvent): String {
+    fun determineAuthorDisplayName(event: CommandEvent): Mono<String> {
         return determineDisplayName(event, event.author)
     }
 
-    fun determineDisplayName(event: CommandEvent, user: User): String {
+    fun determineDisplayName(event: CommandEvent, user: User): Mono<String> {
+        val fallback = user.name.toMono()
+
         return if (event.channelType == ChannelType.TEXT) {
-            event.guild.getMember(user)!!.effectiveName
+            event.guild.retrieveMember(user).submitMono()
+                    .map { it.effectiveName }
+                    .onErrorResume { fallback }
         } else {
-            user.name
+            fallback
         }
     }
 }


### PR DESCRIPTION
Now that there is no JDA user cache, the `getMember` calls would always return `null` (since this function only retrieves members from the internal cache). The non-null assertion (`!!`) would cause the whole `determineDisplayName()` function to throw an exception.
To fix this, I switched to using `retrieveMember` as it tries to retrieve members from the cache before falling back to a REST call. As this change causes the function to be blocking, I swapped to using `Mono` and proper reactive code. The calls in the `Extensions.kt` can be blocking since they're only used in a reactive context (and therefore it's not vital to make them reactive as well).