### PR TITLE
Don't set delta if conversion fails

### DIFF
--- a/nightscout-api/src/main/java/com/dongtronic/nightscout/Nightscout.kt
+++ b/nightscout-api/src/main/java/com/dongtronic/nightscout/Nightscout.kt
@@ -188,8 +188,12 @@ class Nightscout(baseUrl: String, token: String? = null) : Closeable {
             val convertedBg = BloodGlucoseConverter.convert(sgv, "mg")
 
             if (delta.isNotEmpty()) {
-                val convertedDelta = BloodGlucoseConverter.convert(delta.replace("-".toRegex(), ""), "mg")
-                dto.delta = convertedDelta
+                try {
+                    val convertedDelta = BloodGlucoseConverter.convert(delta.replace("-".toRegex(), ""), "mg")
+                    dto.delta = convertedDelta
+                } catch (e: IllegalArgumentException) {
+                    // invalid delta
+                }
             }
 
             dto.glucose = convertedBg


### PR DESCRIPTION
This fixes `diabot ns` when using CGMs that upload deltas with values that Diabot does not support (like raw delta values).

The details of why this issue arose now seems to be a result of how [Diabox / Bubble](https://www.bubblan.org/) devices upload the BG delta to Nightscout. From the values it uploads, I think it is a smoothed raw value delta: `-119805.516`.