### PR TITLE
Fix permission issue with `admin usernames` commands

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminUsernameCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/AdminUsernameCommand.kt
@@ -8,6 +8,7 @@ import com.dongtronic.diabot.platforms.discord.commands.admin.username.AdminUser
 import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.Command
 import com.jagrosh.jdautilities.command.CommandEvent
+import net.dv8tion.jda.api.Permission
 
 class AdminUsernameCommand(category: Command.Category, parent: Command?) : DiscordCommand(category, parent) {
 
@@ -18,6 +19,7 @@ class AdminUsernameCommand(category: Command.Category, parent: Command?) : Disco
         this.help = "Username rule enforcement"
         this.guildOnly = true
         this.ownerCommand = false
+        this.userPermissions = arrayOf(Permission.ADMINISTRATOR)
         this.aliases = arrayOf("u")
         this.children = arrayOf(
                 AdminUsernamePatternCommand(category, this),

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameDisableCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameDisableCommand.kt
@@ -15,6 +15,7 @@ class AdminUsernameDisableCommand(category: Command.Category, parent: Command?) 
         this.help = "Disable username pattern enforcement"
         this.guildOnly = true
         this.aliases = arrayOf("d")
+        this.userPermissions = this.parent!!.userPermissions
     }
 
     override fun execute(event: CommandEvent) {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameEnableCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameEnableCommand.kt
@@ -15,6 +15,7 @@ class AdminUsernameEnableCommand(category: Command.Category, parent: Command?) :
         this.help = "Enable username pattern enforcement"
         this.guildOnly = true
         this.aliases = arrayOf("e")
+        this.userPermissions = this.parent!!.userPermissions
     }
 
     override fun execute(event: CommandEvent) {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameHintCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernameHintCommand.kt
@@ -15,6 +15,7 @@ class AdminUsernameHintCommand(category: Command.Category, parent: Command?) : D
         this.help = "Set or view username enforcement hint"
         this.guildOnly = true
         this.aliases = arrayOf("h", "help")
+        this.userPermissions = this.parent!!.userPermissions
     }
 
     override fun execute(event: CommandEvent) {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernamePatternCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/admin/username/AdminUsernamePatternCommand.kt
@@ -15,6 +15,7 @@ class AdminUsernamePatternCommand(category: Command.Category, parent: Command?) 
         this.help = "Set or view username enforcement pattern"
         this.guildOnly = true
         this.aliases = arrayOf("p", "pat", "s", "set")
+        this.userPermissions = this.parent!!.userPermissions
     }
 
     override fun execute(event: CommandEvent) {


### PR DESCRIPTION
Fixes a permissions issue that allowed any user to execute `diabot admin usernames` subcommands and modify the username enforcement settings in a guild