### PR TITLE
Fix delta with Tomato uploaders

### DIFF
--- a/nightscout-api/src/main/java/com/dongtronic/nightscout/Nightscout.kt
+++ b/nightscout-api/src/main/java/com/dongtronic/nightscout/Nightscout.kt
@@ -143,7 +143,9 @@ class Nightscout(baseUrl: String, token: String? = null) : Closeable {
             if (bgsJson.hasNonNull("bgdelta")) {
                 bgDelta = bgsJson.get("bgdelta").asText()
             }
-            if (dto.delta == null) {
+            if (dto.delta == null
+                    // Set delta if the original is zero and the pebble endpoint is providing non-zero delta
+                    || (dto.delta?.original == 0.0 && bgDelta.toDouble() != 0.0)) {
                 dto.deltaIsNegative = bgDelta.contains("-")
                 dto.delta = BloodGlucoseConverter.convert(bgDelta.replace("-".toRegex(), ""), dto.units)
             }


### PR DESCRIPTION
Tomato uploaders may set the delta value to `0` for every reading. Currently, the pebble endpoint delta would only be used if the delta key was not set before, so a zero value wouldn't be replaced if the pebble endpoint gave a new delta. This PR fixes that by replacing the zero delta if the pebble delta isn't zero. 