### PR TITLE
Quote Improvements

### DIFF
--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // JDA
     implementation 'com.jagrosh:jda-utilities:3.0.4'
-    implementation('net.dv8tion:JDA:4.2.0_209') {
+    implementation('net.dv8tion:JDA:4.3.0_277') {
         exclude module: 'opus-java'
     }
 

--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     // JDA
+    implementation 'com.github.MinnDevelopment:jda-ktx:1223d5cbb8'
     implementation 'com.jagrosh:jda-utilities:3.0.4'
     implementation('net.dv8tion:JDA:4.3.0_277') {
         exclude module: 'opus-java'

--- a/bot/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDAO.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDAO.kt
@@ -10,6 +10,7 @@ import com.mongodb.client.model.Updates
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.reactivestreams.client.MongoCollection
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 import net.dv8tion.jda.api.entities.TextChannel
 import org.bson.conversions.Bson
 import org.litote.kmongo.descending
@@ -211,6 +212,34 @@ class QuoteDAO private constructor() {
             }
 
             val numOfQuotes = getInstance().quoteAmount(channel.guild.id).block() ?: -1
+            if (checkQuoteLimit && numOfQuotes >= getInstance().maxQuotes) {
+                channel.sendMessage("Could not create quote as your guild has reached " +
+                        "the max of ${getInstance().maxQuotes} quotes").queue()
+                return false
+            }
+            return true
+        }
+
+        /**
+         * Checks the restrictions for the guild which the channel belongs to.
+         * This awaits the guild quote amount from [quoteAmount].
+         *
+         * @param channel the channel to send messages to
+         * @param warnDisabledGuild whether to send a warning message when the guild is not enabled for quotes
+         * @param checkQuoteLimit whether to check if the guild has reached the max quote limit
+         * @return true if the guild passed restrictions, false if not
+         */
+        suspend fun awaitCheckRestrictions(channel: TextChannel,
+                              warnDisabledGuild: Boolean = false,
+                              checkQuoteLimit: Boolean = true): Boolean {
+            if (!getInstance().enabledGuilds.contains(channel.guild.id)) {
+                if (warnDisabledGuild) {
+                    channel.sendMessage("This guild is not permitted to use the quoting system").queue()
+                }
+                return false
+            }
+
+            val numOfQuotes = getInstance().quoteAmount(channel.guild.id).awaitSingleOrNull() ?: -1
             if (checkQuoteLimit && numOfQuotes >= getInstance().maxQuotes) {
                 channel.sendMessage("Could not create quote as your guild has reached " +
                         "the max of ${getInstance().maxQuotes} quotes").queue()

--- a/bot/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDTO.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDTO.kt
@@ -50,6 +50,6 @@ data class QuoteDTO(
     }
 
     companion object {
-        const val DISCORD_MESSAGE_LINK = "https://discordapp.com/channels/{guild}/{channel}/{message}"
+        const val DISCORD_MESSAGE_LINK = "https://discord.com/channels/{guild}/{channel}/{message}"
     }
 }

--- a/bot/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDTO.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDTO.kt
@@ -1,6 +1,7 @@
 package com.dongtronic.diabot.data.mongodb
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.JsonIgnore
 
 /**
  * @property quoteId the quote's ID
@@ -38,6 +39,7 @@ data class QuoteDTO(
      *
      * @return a message link pointing to the quote, otherwise `null` if a link cannot be created
      */
+    @JsonIgnore
     fun getMessageLink(): String? {
         if (!hasMessageLink())
             return null

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -91,7 +91,12 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
      */
     private fun addEmbedFooter(quoteDTO: QuoteDTO, builder: EmbedBuilder): EmbedBuilder {
         val footer = StringBuilder("\n")
-        footer.append("- ").append(quoteDTO.author)
+        if (quoteDTO.authorId != "0") {
+            // adding the author name in parentheses is to work around the @invalid-user bug on mobile
+            footer.append("- <@${quoteDTO.authorId}> (${quoteDTO.author})")
+        } else {
+            footer.append("- ").append(quoteDTO.author)
+        }
 
         quoteDTO.getMessageLink()?.let { jumpLink ->
             val jumpText = "[(Jump)]($jumpLink)"

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -13,7 +13,7 @@ import reactor.core.publisher.Mono
 import java.time.Instant
 
 class QuoteCommand(category: Category) : DiscordCommand(category, null) {
-    val mentionsRegex = Regex("<@!(?<uid>\\d+)>")
+    val mentionsRegex = Regex("<@!?(?<uid>\\d+)>")
     private val logger = logger()
 
     init {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -53,8 +53,7 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
         }
 
         quote.subscribe({
-            val messageStripped = stripMentions(it.message, event)
-            event.reply(createEmbed(it.copy(message = messageStripped)))
+            event.reply(createEmbed(it))
         }, {
             event.replyError("Could not find any quote")
             if (it !is NoSuchElementException) {
@@ -119,45 +118,5 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
      */
     private fun getRandomQuote(guildId: String, filter: Bson? = null): Mono<QuoteDTO> {
         return QuoteDAO.getInstance().getRandomQuote(guildId, filter)
-    }
-
-    /**
-     * Strips a message of mentions for users inside the guild.
-     * Mentions which reference a user who is not in the guild will not be stripped.
-     *
-     * @param message the message to strip of mentions
-     * @param event command event
-     * @return stripped message
-     */
-    private fun stripMentions(message: String, event: CommandEvent): String {
-        var strippedMessage = message
-        val matches = mentionsRegex.findAll(message)
-        // using `toMap` to remove duplicate mentions
-        val uidMap = matches.mapNotNull {
-            val uid = it.groups["uid"]?.value ?: return@mapNotNull null
-            it.value to uid
-        }.toMap()
-
-        // replace the ids with their real names
-        uidMap.mapValues { resolveNameById(it.value, event) }
-                .forEach { (match, id) ->
-                    if (id.isBlank())
-                        return@forEach
-
-                    strippedMessage = strippedMessage.replace(match, "@$id")
-                }
-
-        return strippedMessage
-    }
-
-    /**
-     * Gets a nickname or account name by a Discord account ID if it is in the same guild
-     *
-     * @param id Discord account ID
-     * @param event command event
-     * @return account name if the id was found in the guild, otherwise blank
-     */
-    private fun resolveNameById(id: String, event: CommandEvent): String {
-        return event.guild.getMemberById(id)?.effectiveName ?: ""
     }
 }

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -13,7 +13,6 @@ import reactor.core.publisher.Mono
 import java.time.Instant
 
 class QuoteCommand(category: Category) : DiscordCommand(category, null) {
-    val mentionsRegex = Regex("<@!?(?<uid>\\d+)>")
     private val logger = logger()
 
     init {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -36,9 +36,9 @@ class QuoteListener(private val client: CommandClient) : ListenerAdapter() {
         /**
          * Replies to the channel only if the reacting user has permission to send messages
          */
-        val reply: (() -> MessageAction) -> Unit = { msg ->
+        val reply: (() -> MessageAction) -> Unit = { message ->
             if (event.channel.canTalk(event.member)) {
-                msg().queue()
+                message().queue()
             }
         }
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -56,7 +56,7 @@ class QuoteListener(private val client: CommandClient) : ListenerAdapter() {
                     messageId = message.id
             )).subscribe({
                 message.addReaction(speechEmoji).queue()
-                reply("New quote added by ${author.effectiveName} as #${it.quoteId}")
+                reply("New quote added by ${author.effectiveName} as #${it.quoteId} (<${message.jumpUrl}>)")
             }, {
                 reply("Could not create quote for message: ${message.id}")
             })

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ allprojects {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+        implementation "org.jetbrains.kotlin:kotlin-reflect:1.5.31"
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.5.2'
         testImplementation group: 'junit', name: 'junit', version: '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        maven { url 'https://m2.dv8tion.net/releases' }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
     id 'io.gitlab.arturbosch.detekt' version '1.18.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,13 @@ allprojects {
         jcenter()
         mavenCentral()
         maven { url 'https://m2.dv8tion.net/releases' }
+        maven { url 'https://jitpack.io' }
     }
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+        implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
+        implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.5.2'
         testImplementation group: 'junit', name: 'junit', version: '4.12'
         api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     }


### PR DESCRIPTION
Build:
- Update Kotlin and JDA to 1.5.31 and 4.3.0_277 respectively
- Add explicit `kotlin-reflect` dependency to avoid version differences between it and the Kotlin stdlib

Features:
- Add jump URL for reaction-quoted messages
- Use `discord.com` for jump URLs
- Mention the quoter when a quote is added
- Don't strip mentions from quotes
- Mention the author of the quote whenever possible in the quote embed
- Allow mentioning authors outside the guild when adding a quote manually: `diabot quote add "test" - <@someones_id_who_is_not_in_the_guild>`

Refactors:
- Convert `quote add` command to use coroutines

Bug fixes:
- Detect mentions without nicknames (`<@USERID>` instead of `<@!USERID>`)
- Don't serialize `messageLink` for quote DTOs. This is a bug which led to the quotes' message jump links being stored in the database, meaning we'll need to add a database migration (once #133 is implemented) to deal with the previous quotes containing `messageLink` fields