### PR TITLE
Centralize dependency versions in one file

### DIFF
--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -1,44 +1,44 @@
 dependencies {
     // JDA
-    implementation 'com.github.MinnDevelopment:jda-ktx:1223d5cbb8'
-    implementation 'com.jagrosh:jda-utilities:3.0.4'
-    implementation('net.dv8tion:JDA:4.3.0_277') {
+    implementation "com.github.MinnDevelopment:jda-ktx:${jdaKtxVersion}"
+    implementation "com.jagrosh:jda-utilities:${jdaUtilitiesVersion}"
+    implementation("net.dv8tion:JDA:${jdaVersion}") {
         exclude module: 'opus-java'
     }
 
     // Logging
-    implementation 'ch.qos.logback:logback-classic:1.0.13'
+    implementation "ch.qos.logback:logback-classic:${logbackVersion}"
 
     // Parsing
-    implementation 'com.rometools:rome:1.11.1'
-    implementation 'org.jsoup:jsoup:1.11.3'
+    implementation "com.rometools:rome:${romeVersion}"
+    implementation "org.jsoup:jsoup:${jsoupVersion}"
 
     // Apache Commons
-    implementation 'org.apache.commons:commons-lang3:3.8.1'
-    implementation 'commons-configuration:commons-configuration:1.6'
+    implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
+    implementation "commons-configuration:commons-configuration:${commonsConfigurationVersion}"
 
     // Networking
-    implementation 'com.squareup.okhttp3:okhttp:4.8.1'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
-    implementation 'com.jakewharton.retrofit:retrofit2-reactor-adapter:2.1.0'
+    implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
+    implementation "com.squareup.retrofit2:retrofit:${retrofitVersion}"
+    implementation "com.squareup.retrofit2:converter-jackson:${retrofitVersion}"
+    implementation "com.jakewharton.retrofit:retrofit2-reactor-adapter:${retrofitReactorVersion}"
 
     // Database
-    implementation 'redis.clients:jedis:3.3.0'
-    implementation 'org.mongodb:mongodb-driver-reactivestreams:4.0.5'
-    implementation 'org.litote.kmongo:kmongo-async:4.0.3'
+    implementation "redis.clients:jedis:${jedisVersion}"
+    implementation "org.mongodb:mongodb-driver-reactivestreams:${mongodbVersion}"
+    implementation "org.litote.kmongo:kmongo-async:${kmongoVersion}"
 
     // Database Migrations
-    implementation "com.github.cloudyrock.mongock:mongock-standalone:5.0.1.BETA"
-    implementation "com.github.cloudyrock.mongock:mongodb-sync-v4-driver:5.0.2.BETA"
-    implementation "org.litote.kmongo:kmongo:4.0.3"
+    implementation "com.github.cloudyrock.mongock:mongock-standalone:${mongockRunnerVersion}"
+    implementation "com.github.cloudyrock.mongock:mongodb-sync-v4-driver:${mongockDriverVersion}"
+    implementation "org.litote.kmongo:kmongo:${kmongoVersion}"
 
     // Cache
-    implementation 'com.github.ben-manes.caffeine:caffeine:2.8.5'
+    implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
 
     // Misc
     implementation project(':utilities')
     implementation project(':nightscout-api')
-    implementation 'io.projectreactor:reactor-core:3.3.8.RELEASE'
-    implementation 'io.projectreactor.kotlin:reactor-kotlin-extensions:1.0.2.RELEASE'
+    implementation "io.projectreactor:reactor-core:${reactorCoreVersion}"
+    implementation "io.projectreactor.kotlin:reactor-kotlin-extensions:${reactorKotlinVersion}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
-    id 'io.gitlab.arturbosch.detekt' version '1.18.1'
+    id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}"
+    id 'com.github.johnrengelman.shadow' version "${shadowVersion}"
+    id 'io.gitlab.arturbosch.detekt' version "${detektVersion}"
 }
 
 allprojects {
@@ -16,12 +16,12 @@ allprojects {
     }
 
     dependencies {
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-        implementation "org.jetbrains.kotlin:kotlin-reflect:1.5.31"
-        implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
-        implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.5.2'
-        testImplementation group: 'junit', name: 'junit', version: '4.12'
-        api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}"
+        implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
+        implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${kotlinCoroutinesVersion}"
+        implementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${kotlinCoroutinesVersion}"
+        testImplementation group: 'junit', name: 'junit', version: "${junitVersion}"
+        api group: 'org.slf4j', name: 'slf4j-api', version: "${slf4jVersion}"
     }
 
     group = 'com.dongtronic.diabot'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,44 @@
+shadowVersion = 6.1.0
+detektVersion = 1.18.1
+kotlinVersion = 1.5.31
+kotlinCoroutinesVersion = 1.5.2
+junitVersion = 4.12
+
+# Logging
+slf4jVersion = 1.7.25
+logbackVersion = 1.0.13
+
+# Project Reactor
+reactorCoreVersion = 3.3.8.RELEASE
+reactorKotlinVersion = 1.0.2.RELEASE
+
+# JDA
+jdaVersion = 4.3.0_277
+jdaUtilitiesVersion = 3.0.4
+jdaKtxVersion = 1223d5cbb8
+
+# Parsing
+romeVersion = 1.11.1
+jsoupVersion = 1.11.3
+jacksonVersion = 2.11.3
+
+# Apache Commons
+commonsLangVersion = 3.8.1
+commonsConfigurationVersion = 1.6
+
+# Networking
+okhttpVersion = 4.8.1
+retrofitVersion = 2.9.0
+retrofitReactorVersion = 2.1.0
+
+# Database
+jedisVersion = 3.3.0
+mongodbVersion = 4.0.5
+kmongoVersion = 4.0.3
+
+# Database Migration
+mongockRunnerVersion = 5.0.1.BETA
+mongockDriverVersion = 5.0.2.BETA
+
+# Cache
+caffeineVersion = 2.8.5

--- a/nightscout-api/build.gradle
+++ b/nightscout-api/build.gradle
@@ -2,18 +2,18 @@ group 'com.dongtronic'
 
 dependencies {
     // Networking
-    implementation 'com.squareup.okhttp3:okhttp:4.8.1'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
-    implementation 'com.jakewharton.retrofit:retrofit2-reactor-adapter:2.1.0'
+    implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
+    implementation "com.squareup.retrofit2:retrofit:${retrofitVersion}"
+    implementation "com.squareup.retrofit2:converter-jackson:${retrofitVersion}"
+    implementation "com.jakewharton.retrofit:retrofit2-reactor-adapter:${retrofitReactorVersion}"
 
-    api 'org.litote.kmongo:kmongo-shared:4.0.3'
+    api "org.litote.kmongo:kmongo-shared:${kmongoVersion}"
 
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
-    api group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.11.3'
+    api group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: "${jacksonVersion}"
 
     // Misc
     implementation project(':utilities')
-    implementation 'io.projectreactor:reactor-core:3.3.8.RELEASE'
-    implementation 'io.projectreactor.kotlin:reactor-kotlin-extensions:1.0.2.RELEASE'
+    implementation "io.projectreactor:reactor-core:${reactorCoreVersion}"
+    implementation "io.projectreactor.kotlin:reactor-kotlin-extensions:${reactorKotlinVersion}"
 }


### PR DESCRIPTION
**This PR is based off of #138, so don't merge this until that PR is merged.**

This PR moves all of the dependency/plugin version declarations into the `gradle.properties` file, which will help ensure versions of dependencies are consistent across projects and allow easier updating of libraries which have multiple dependencies that share version numbers.