### PR TITLE
Fix invite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A diabetes bot for Discord
 
 ## Adding Diabot to your server
-Use [this invite link](https://discord.com/oauth2/authorize?client_id=260721031038238720&scope=applications.commands+bot&permissions=2550492224&guild_id=0)
+Use [this invite link](https://discord.com/oauth2/authorize?client_id=260721031038238720&scope=applications.commands+bot&permissions=2550492224)
 
 ## Administration documentation
 See documentation for admin commands [here](docs/administration.md).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A diabetes bot for Discord
 
 ## Adding Diabot to your server
-Use [this invite link](https://discordapp.com/oauth2/authorize?client_id=260721031038238720&scope=applications.commands+bot&permissions=2550492224&guild_id=0)
+Use [this invite link](https://discord.com/oauth2/authorize?client_id=260721031038238720&scope=applications.commands+bot&permissions=2550492224&guild_id=0)
 
 ## Administration documentation
 See documentation for admin commands [here](docs/administration.md).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A diabetes bot for Discord
 
 ## Adding Diabot to your server
-Use [this invite link](https://discordapp.com/oauth2/authorize?client_id=260721031038238720&scope=bot&scope=applications.commands&permissions=403008576&guild_id=0)
+Use [this invite link](https://discordapp.com/oauth2/authorize?client_id=260721031038238720&scope=applications.commands+bot&permissions=2550492224&guild_id=0)
 
 ## Administration documentation
 See documentation for admin commands [here](docs/administration.md).


### PR DESCRIPTION
The invite link in the README was not working (I believe because two `scope` parameters were used instead of one with `+` separators between each scope). I fixed this, adjusted the permission to match the ones provided in the about command, and changed the link to Discord's new URL.