### PR TITLE
Fix formatting of about command

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/AboutCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/AboutCommand.kt
@@ -29,7 +29,7 @@ class AboutCommand(category: Category, private val color: Color, private val des
                 val info = event.jda.retrieveApplicationInfo().complete()
                 if (info.isBotPublic) {
                     info.setRequiredScopes("applications.commands")
-                    info.getInviteUrl(0L, *perms)
+                    info.getInviteUrl(*perms)
                 } else ""
             } catch (e: Exception) {
                 log.error("Could not generate invite link ", e)

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/AboutCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/AboutCommand.kt
@@ -80,10 +80,10 @@ class AboutCommand(category: Category, private val color: Color, private val des
         description.append(" ```")
         builder.setDescription(description)
 
-        builder.addField("Stats", """${event.client.totalGuilds} Servers \\n Shard ${event.jda.shardInfo.shardId + 1}/${event.jda.shardInfo.shardTotal}""", true)
+        builder.addField("Stats", "${event.client.totalGuilds} Servers \n Shard ${event.jda.shardInfo.shardId + 1}/${event.jda.shardInfo.shardTotal}", true)
 
-        builder.addField("This shard", """${event.jda.users.size} Users \\n ${event.jda.guilds.size} Servers""", true)
-        builder.addField("", """${event.jda.textChannels.size} Text Channels \\n ${event.jda.voiceChannels.size} Voice Channels""", true)
+        builder.addField("This shard", "${event.jda.users.size} Users \n ${event.jda.guilds.size} Servers", true)
+        builder.addField("", "${event.jda.textChannels.size} Text Channels \n ${event.jda.voiceChannels.size} Voice Channels", true)
         builder.setFooter("Last restart", null)
         builder.setTimestamp(event.client.startTime)
         event.reply(builder.build())

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/AboutCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/info/AboutCommand.kt
@@ -60,12 +60,12 @@ class AboutCommand(category: Category, private val color: Color, private val des
 
         val description = StringBuilder()
                 .append("Hello! I am **${event.selfUser.name}**, ")
-                .append(description)
+                .append("$description.")
                 .append("\nI was written in Kotlin by **$author**")
-                .append("using ${JDAUtilitiesInfo.AUTHOR}'s [Commands Extension](${JDAUtilitiesInfo.GITHUB})")
-                .append(" and the [JDA library](https://github.com/DV8FromTheWorld/JDA)")
-                .append("\nType `${event.client.textualPrefix} ${event.client.helpWord}` to see my commands!")
-                .append(inviteMessage)
+                .append(" using ${JDAUtilitiesInfo.AUTHOR}'s [Commands Extension](${JDAUtilitiesInfo.GITHUB})")
+                .append(" and the [JDA library](https://github.com/DV8FromTheWorld/JDA).")
+                .append("\nType `${event.client.textualPrefix}${event.client.helpWord}` to see my commands!")
+                .append(" $inviteMessage.")
                 .append("\n\nSome of my features include: ```css")
 
         for (feature in features) {


### PR DESCRIPTION
This PR cleans up/fixes the formatting of the `diabot about` command:

- `\n`'s are now actual newlines
- Invite link no longer includes the `guild_id` parameter
- Added a space after the bot author
- There is no longer an extra space between the bot prefix and the help command
- Added a space between the help sentence and the invite sentence
- Added periods to the end of each line