### PR TITLE
Refactor BG conversion code (and consequently fix multiple conversions)

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConversionApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConversionApplicationCommand.kt
@@ -29,6 +29,12 @@ class ConversionApplicationCommand : ApplicationCommand {
         val glucoseUnit = event.getOption(commandArgUnit)?.asString
 
         val result = BloodGlucoseConverter.convert(glucoseNumber, glucoseUnit)
+                .getOrElse {
+                    if (it is IllegalArgumentException) {
+                        event.reply("Could not convert: ${it.message}").queue()
+                    }
+                    return
+                }
 
         val reply = when {
             result.inputUnit === GlucoseUnit.MMOL -> String.format("%s mmol/L is %s mg/dL", result.mmol, result.mgdl)

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConvertCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConvertCommand.kt
@@ -51,16 +51,8 @@ class ConvertCommand(category: Command.Category) : DiscordCommand(category, null
 
                 event.reply(reply)
 
-                // #20: Reply with :smirk: when value is 69 mg/dL or 6.9 mmol/L
-                if (result.mmol == 6.9 || result.mgdl == 69) {
-                    event.message.addReaction("\uD83D\uDE0F").queue()
-                }
-
-                // #36 and #60: Reply with :100: when value is 100 mg/dL, 5.5 mmol/L, or 10.0 mmol/L
-                if (result.mmol == 5.5
-                        || result.mmol == 10.0
-                        || result.mgdl == 100) {
-                    event.message.addReaction("\uD83D\uDCAF").queue()
+                BloodGlucoseConverter.getReactions(result).forEach {
+                    event.message.addReaction(it).queue()
                 }
 
             } catch (ex: IllegalArgumentException) {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConvertCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConvertCommand.kt
@@ -1,6 +1,5 @@
 package com.dongtronic.diabot.platforms.discord.commands.diabetes
 
-import com.dongtronic.diabot.data.ConversionDTO
 import com.dongtronic.diabot.exceptions.UnknownUnitException
 import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
 import com.dongtronic.diabot.logic.diabetes.GlucoseUnit
@@ -32,37 +31,34 @@ class ConvertCommand(category: Command.Category) : DiscordCommand(category, null
             // split the arguments on all whitespaces
             val args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
-            val result: ConversionDTO?
-
-            try {
-                result = BloodGlucoseConverter.convert(args[0], if (args.size == 2) args[1] else null)
-
-                val reply = when {
-                    result.inputUnit === GlucoseUnit.MMOL -> String.format("%s mmol/L is %s mg/dL", result.mmol, result.mgdl)
-                    result.inputUnit === GlucoseUnit.MGDL -> String.format("%s mg/dL is %s mmol/L", result.mgdl, result.mmol)
-                    else -> {
-                        String.format(arrayOf(
-                                "*I'm not sure if you gave me mmol/L or mg/dL, so I'll give you both.*",
-                                "%s mg/dL is **%s mmol/L**",
-                                "%s mmol/L is **%s mg/dL**").joinToString(
-                                "%n"), args[0], result.mmol, args[0], result.mgdl)
+            val result = BloodGlucoseConverter.convert(args[0], args.getOrNull(1))
+                    .getOrElse {
+                        if (it is IllegalArgumentException) {
+                            // Ignored on purpose
+                            logger.warn("IllegalArgumentException occurred but was ignored in BG conversion")
+                        } else if (it is UnknownUnitException) {
+                            event.replyError("I don't know how to convert from " + args[1])
+                        }
+                        return
                     }
+
+            val reply = when {
+                result.inputUnit === GlucoseUnit.MMOL -> String.format("%s mmol/L is %s mg/dL", result.mmol, result.mgdl)
+                result.inputUnit === GlucoseUnit.MGDL -> String.format("%s mg/dL is %s mmol/L", result.mgdl, result.mmol)
+                else -> {
+                    String.format(arrayOf(
+                            "*I'm not sure if you gave me mmol/L or mg/dL, so I'll give you both.*",
+                            "%s mg/dL is **%s mmol/L**",
+                            "%s mmol/L is **%s mg/dL**").joinToString(
+                            "%n"), args[0], result.mmol, args[0], result.mgdl)
                 }
-
-                event.reply(reply)
-
-                BloodGlucoseConverter.getReactions(result).forEach {
-                    event.message.addReaction(it).queue()
-                }
-
-            } catch (ex: IllegalArgumentException) {
-                // Ignored on purpose
-                logger.warn("IllegalArgumentException occurred but was ignored in BG conversion")
-            } catch (ex: UnknownUnitException) {
-                event.replyError("I don't know how to convert from " + args[1])
-                logger.warn("Unknown BG unit " + args[1])
             }
 
+            event.reply(reply)
+
+            BloodGlucoseConverter.getReactions(result).forEach {
+                event.message.addReaction(it).queue()
+            }
         }
     }
 }

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/EstimationApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/EstimationApplicationCommand.kt
@@ -46,7 +46,10 @@ class EstimationApplicationCommand : ApplicationCommand {
     private fun estimateAverage(event: SlashCommandEvent) {
         val input = event.getOption(commandArgA1c)!!
 
-        val result = A1cConverter.estimateAverage(input.asString)
+        val result = A1cConverter.estimateAverage(input.asString).getOrElse {
+            event.reply("Could not estimate average BG: ${it.message}").queue()
+            return
+        }
 
         event.reply(
                 String.format("An A1c of **%s%%** (DCCT) or **%s mmol/mol** (IFCC) is about **%s mg/dL** or **%s mmol/L**",
@@ -59,6 +62,10 @@ class EstimationApplicationCommand : ApplicationCommand {
         val inputUnit = event.getOption(commandArgUnit)
 
         val result = A1cConverter.estimateA1c(inputNumber.asString, inputUnit?.asString)
+                .getOrElse {
+                    event.reply("Could not estimate A1c: ${it.message}").queue()
+                    return
+                }
 
         val message = when (result.original.inputUnit) {
             GlucoseUnit.MMOL -> String.format("An average of %s mmol/L is about **%s%%** (DCCT) or **%s mmol/mol** (IFCC)", result.original.mmol, result.dcct, result.ifcc)

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
@@ -8,6 +8,7 @@ import com.dongtronic.diabot.exceptions.NightscoutDataException
 import com.dongtronic.diabot.exceptions.NightscoutPrivateException
 import com.dongtronic.diabot.exceptions.NightscoutStatusException
 import com.dongtronic.diabot.exceptions.UnconfiguredNightscoutException
+import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
 import com.dongtronic.diabot.nameOf
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.logic.NightscoutFacade
@@ -405,15 +406,8 @@ class NightscoutCommand(category: Category) : DiscordCommand(category, null) {
      * @param response The message to react to.
      */
     private fun addReactions(dto: NightscoutDTO, response: Message) {
-        // #20: Reply with :smirk: when value is 69 mg/dL or 6.9 mmol/L
-        if (dto.glucose!!.mgdl == 69 || dto.glucose!!.mmol == 6.9) {
-            response.addReaction("\uD83D\uDE0F").queue()
-        }
-        // #36 and #60: Reply with :100: when value is 100 mg/dL, 5.5 mmol/L, or 10.0 mmol/L
-        if (dto.glucose!!.mgdl == 100
-                || dto.glucose!!.mmol == 5.5
-                || dto.glucose!!.mmol == 10.0) {
-            response.addReaction("\uD83D\uDCAF").queue()
+        BloodGlucoseConverter.getReactions(dto.glucose!!.mmol, dto.glucose!!.mgdl).forEach {
+            response.addReaction(it).queue()
         }
     }
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -80,16 +80,8 @@ class ConversionListener : ListenerAdapter() {
                 }
             }
 
-            // #20: Reply with :smirk: when value is 69 mg/dL or 6.9 mmol/L
-            if (result.mmol == 6.9 || result.mgdl == 69) {
-                event.message.addReaction("\uD83D\uDE0F").queue()
-            }
-
-            // #36 and #60: Reply with :100: when value is 100 mg/dL, 5.5 mmol/L, or 10.0 mmol/L
-            if (result.mmol == 5.5
-                    || result.mmol == 10.0
-                    || result.mgdl == 100) {
-                event.message.addReaction("\uD83D\uDCAF").queue()
+            BloodGlucoseConverter.getReactions(result).forEach {
+                event.message.addReaction(it).queue()
             }
 
             return finalMessage

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -33,23 +33,30 @@ class ConversionListener : ListenerAdapter() {
         val inlineMatches = Patterns.inlineBgPattern.findAll(previousMessageText)
         val unitMatches = Patterns.unitBgPattern.findAll(previousMessageText)
 
-        return unitMatches
+        val sortedMatches = unitMatches
                 .plus(inlineMatches)
                 .filter { it.groups["value"] != null }
                 .sortedBy { it.range.first }
-                .joinToString("\n") {
-                    val number = it.groups["value"]!!.value
-                    val unit = if (it.groups.size == 3) {
-                        it.groups["unit"]?.value ?: ""
-                    } else {
-                        ""
-                    }
 
-                    getResult(number, unit, event)
-                }
+        val multipleMatches = sortedMatches.count() > 1
+
+        return sortedMatches.joinToString("\n") {
+            val number = it.groups["value"]!!.value
+            val unit = if (it.groups.size == 3) {
+                it.groups["unit"]?.value ?: ""
+            } else {
+                ""
+            }
+
+            getResult(number, unit, event, multipleMatches)
+        }
     }
 
-    private fun getResult(originalNumString: String, originalUnitString: String, event: GuildMessageReceivedEvent): String {
+    private fun getResult(originalNumString: String,
+                          originalUnitString: String,
+                          event: GuildMessageReceivedEvent,
+                          multipleMatches: Boolean = false): String {
+        val separator = if (multipleMatches) "─ " else ""
         val numberString = originalNumString.replace(',', '.')
 
         try {
@@ -64,13 +71,13 @@ class ConversionListener : ListenerAdapter() {
             }
 
             return when {
-                result.inputUnit === GlucoseUnit.MMOL -> String.format("%s mmol/L is %s mg/dL", result.mmol, result.mgdl)
-                result.inputUnit === GlucoseUnit.MGDL -> String.format("%s mg/dL is %s mmol/L", result.mgdl, result.mmol)
+                result.inputUnit === GlucoseUnit.MMOL -> String.format("$separator%s mmol/L is %s mg/dL", result.mmol, result.mgdl)
+                result.inputUnit === GlucoseUnit.MGDL -> String.format("$separator%s mg/dL is %s mmol/L", result.mgdl, result.mmol)
                 else -> {
                     val reply = arrayOf(
-                            "*I'm not sure if you gave me mmol/L or mg/dL, so I'll give you both.*",
-                            "%s mg/dL is **%s mmol/L**",
-                            "%s mmol/L is **%s mg/dL**").joinToString(
+                            "$separator*I'm not sure if you gave me mmol/L or mg/dL, so I'll give you both.*",
+                            "┌%s mg/dL is **%s mmol/L**",
+                            "└%s mmol/L is **%s mg/dL**").joinToString(
                             "%n")
 
                     String.format(reply, numberString, result.mmol, numberString, result.mgdl)

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -32,13 +32,11 @@ class ConversionListener : ListenerAdapter() {
         val inlineMatches = Patterns.inlineBgPattern.findAll(previousMessageText)
         val unitMatches = Patterns.unitBgPattern.findAll(previousMessageText)
 
-        val getNumberUnit: (MatchResult) -> (Pair<String, String>) = {
-            it.groups["value"]!!.value to
-                    if (it.groups.size == 3) {
-                        it.groups["unit"]?.value ?: ""
-                    } else {
-                        ""
-                    }
+        val getNumberUnit: (MatchResult) -> (Pair<String, String?>) = {
+            val number = it.groups["value"]!!.value
+            val unit = kotlin.runCatching { it.groups["unit"]?.value }.getOrNull()
+
+            number to unit
         }
 
         val sortedMatches = unitMatches

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -33,30 +33,30 @@ class ConversionListener : ListenerAdapter() {
         val inlineMatches = Patterns.inlineBgPattern.findAll(previousMessageText)
         val unitMatches = Patterns.unitBgPattern.findAll(previousMessageText)
 
+        val getNumberUnit: (MatchResult) -> (Pair<String, String>) = {
+            it.groups["value"]!!.value to
+                    if (it.groups.size == 3) {
+                        it.groups["unit"]?.value ?: ""
+                    } else {
+                        ""
+                    }
+        }
+
         val sortedMatches = unitMatches
                 .plus(inlineMatches)
                 .filter { it.groups["value"] != null }
                 .sortedBy { it.range.first }
                 .distinctBy {
-                    it.groups["value"]!!.value +
-                            if (it.groups.size == 3) {
-                                it.groups["unit"]?.value ?: ""
-                            } else {
-                                ""
-                            }
+                    val pair = getNumberUnit(it)
+                    pair.first + pair.second
                 }
 
         val multipleMatches = sortedMatches.count() > 1
 
         return sortedMatches.joinToString("\n") {
-            val number = it.groups["value"]!!.value
-            val unit = if (it.groups.size == 3) {
-                it.groups["unit"]?.value ?: ""
-            } else {
-                ""
-            }
+            val resultPair = getNumberUnit(it)
 
-            getResult(number, unit, event, multipleMatches)
+            getResult(resultPair.first, resultPair.second, event, multipleMatches)
         }
     }
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -60,15 +60,15 @@ class ConversionListener : ListenerAdapter() {
                 numberString = numberString.replace(',', '.')
             }
 
-            val result: ConversionDTO? = if (originalUnitString.length > 1) {
+            val result: ConversionDTO = if (originalUnitString.length > 1) {
                 BloodGlucoseConverter.convert(numberString, originalUnitString)
             } else {
                 BloodGlucoseConverter.convert(numberString, null)
             }
 
             finalMessage += when {
-                result!!.inputUnit === GlucoseUnit.MMOL -> String.format("%s mmol/L is %s mg/dL", result!!.mmol, result.mgdl)
-                result!!.inputUnit === GlucoseUnit.MGDL -> String.format("%s mg/dL is %s mmol/L", result!!.mgdl, result.mmol)
+                result.inputUnit === GlucoseUnit.MMOL -> String.format("%s mmol/L is %s mg/dL", result.mmol, result.mgdl)
+                result.inputUnit === GlucoseUnit.MGDL -> String.format("%s mg/dL is %s mmol/L", result.mgdl, result.mmol)
                 else -> {
                     val reply = arrayOf(
                             "*I'm not sure if you gave me mmol/L or mg/dL, so I'll give you both.*",
@@ -76,7 +76,7 @@ class ConversionListener : ListenerAdapter() {
                             "%s mmol/L is **%s mg/dL**").joinToString(
                             "%n")
 
-                    String.format(reply, numberString, result!!.mmol, numberString, result.mgdl)
+                    String.format(reply, numberString, result.mmol, numberString, result.mgdl)
                 }
             }
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -37,6 +37,14 @@ class ConversionListener : ListenerAdapter() {
                 .plus(inlineMatches)
                 .filter { it.groups["value"] != null }
                 .sortedBy { it.range.first }
+                .distinctBy {
+                    it.groups["value"]!!.value +
+                            if (it.groups.size == 3) {
+                                it.groups["unit"]?.value ?: ""
+                            } else {
+                                ""
+                            }
+                }
 
         val multipleMatches = sortedMatches.count() > 1
 

--- a/bot/src/main/java/com/dongtronic/diabot/util/Patterns.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/util/Patterns.kt
@@ -3,9 +3,28 @@ package com.dongtronic.diabot.util
 import java.util.regex.Pattern
 
 object Patterns {
-    val inlineBgPattern = Pattern.compile("^.*\\s_([0-9]{1,3}[.,]?[0-9]?)_.*$")!!
+    /**
+     * Matches BG numbers surrounded by underscores
+     */
+    val inlineBgPattern = Regex("""_(?<value>\d{1,3}(?:[.,]\d+)?)_""")
+
+    /**
+     * Matches a message that is just a BG value, without any extra characters.
+     * There needs to be:
+     * - a BG value in either mg/dL or mmol/L formats (200 OR 200.2)
+     * - nothing else before or after the BG value
+     *
+     * `3.4`
+     * `3.4`
+     * `100`
+     * `100.0`
+     */
     val separateBgPattern = Pattern.compile("^([0-9]{1,3}[.,]?[0-9]?)$")!!
-    val unitBgPattern = Pattern.compile("^((.*\\s-?)|(-?))?([0-9.,]+)\\s?((mmol)|(mg)).*$")!!
+
+    /**
+     * Matches suspected BG values with units
+     */
+    val unitBgPattern = Regex("""(?<value>\d{1,3}(?:[.,]\d+)?) ?(?<unit>mmol|mg)""")
     val feelPattern = Pattern.compile(".*feel it.*")!!
     val ohNoPattern = Pattern.compile("oh no")!!
 }

--- a/bot/src/test/java/com/dongtronic/diabot/converters/BloodGlucoseConverterTest.kt
+++ b/bot/src/test/java/com/dongtronic/diabot/converters/BloodGlucoseConverterTest.kt
@@ -10,86 +10,77 @@ import org.junit.jupiter.api.Test
 class BloodGlucoseConverterTest {
 
     @Test
-    @Throws(Exception::class)
     fun mmolWithUnit() {
 
         val actual = BloodGlucoseConverter.convert("5.5", "mmol")
 
         val expected = ConversionDTO(5.5, 99.0, GlucoseUnit.MMOL)
 
-        Assertions.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual.getOrNull())
     }
 
     @Test
-    @Throws(Exception::class)
     fun mgdlWithUnit() {
         val actual = BloodGlucoseConverter.convert("100", "mgdl")
 
         val expected = ConversionDTO(100.0, 5.6, GlucoseUnit.MGDL)
 
-        Assertions.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual.getOrNull())
     }
 
     @Test
-    @Throws(Exception::class)
     fun mmolWithoutUnit() {
         val actual = BloodGlucoseConverter.convert("5.5", "")
 
         val expected = ConversionDTO(5.5, 99.0, GlucoseUnit.MMOL)
 
-        Assertions.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual.getOrNull())
     }
 
     @Test
-    @Throws(Exception::class)
     fun mgdlWithoutUnit() {
         val actual = BloodGlucoseConverter.convert("100", "")
 
         val expected = ConversionDTO(100.0, 5.6, GlucoseUnit.MGDL)
 
-        Assertions.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual.getOrNull())
     }
 
     @Test
-    @Throws(Exception::class)
     fun negative() {
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            BloodGlucoseConverter.convert("-5.5", "mmol")
-        }
+        val actual = BloodGlucoseConverter.convert("-5.5", "mmol")
+
+        Assertions.assertTrue(actual.exceptionOrNull() is IllegalArgumentException)
     }
 
     @Test
-    @Throws(Exception::class)
     fun tooHigh() {
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            BloodGlucoseConverter.convert("1000", "mmol")
-        }
+        val actual = BloodGlucoseConverter.convert("1000", "mmol")
+
+        Assertions.assertTrue(actual.exceptionOrNull() is IllegalArgumentException)
     }
 
 
     @Test
-    @Throws(Exception::class)
     fun invalidUnit() {
-        Assertions.assertThrows(UnknownUnitException::class.java) {
-            BloodGlucoseConverter.convert("5.5", "what")
-        }
+        val actual = BloodGlucoseConverter.convert("5.5", "what")
+
+        Assertions.assertTrue(actual.exceptionOrNull() is UnknownUnitException)
     }
 
     @Test
-    @Throws(Exception::class)
     fun ambiguous() {
         val actual = BloodGlucoseConverter.convert("27", "")
 
         val expected = ConversionDTO(27.0, 1.5, 486.0)
 
-        Assertions.assertEquals(actual, expected)
+        Assertions.assertEquals(expected, actual.getOrNull())
     }
 
     @Test
-    @Throws(Exception::class)
     fun noInput() {
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            BloodGlucoseConverter.convert("", "")
-        }
+        val actual = BloodGlucoseConverter.convert("", "")
+
+        Assertions.assertTrue(actual.exceptionOrNull() is IllegalArgumentException)
     }
 }

--- a/bot/src/test/java/com/dongtronic/diabot/converters/BloodGlucoseConverterTest.kt
+++ b/bot/src/test/java/com/dongtronic/diabot/converters/BloodGlucoseConverterTest.kt
@@ -4,8 +4,8 @@ import com.dongtronic.diabot.data.ConversionDTO
 import com.dongtronic.diabot.exceptions.UnknownUnitException
 import com.dongtronic.diabot.logic.diabetes.BloodGlucoseConverter
 import com.dongtronic.diabot.logic.diabetes.GlucoseUnit
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 class BloodGlucoseConverterTest {
 
@@ -17,7 +17,7 @@ class BloodGlucoseConverterTest {
 
         val expected = ConversionDTO(5.5, 99.0, GlucoseUnit.MMOL)
 
-        Assert.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual)
     }
 
     @Test
@@ -27,7 +27,7 @@ class BloodGlucoseConverterTest {
 
         val expected = ConversionDTO(100.0, 5.6, GlucoseUnit.MGDL)
 
-        Assert.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual)
     }
 
     @Test
@@ -37,7 +37,7 @@ class BloodGlucoseConverterTest {
 
         val expected = ConversionDTO(5.5, 99.0, GlucoseUnit.MMOL)
 
-        Assert.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual)
     }
 
     @Test
@@ -47,26 +47,32 @@ class BloodGlucoseConverterTest {
 
         val expected = ConversionDTO(100.0, 5.6, GlucoseUnit.MGDL)
 
-        Assert.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     @Throws(Exception::class)
     fun negative() {
-        BloodGlucoseConverter.convert("-5.5", "mmol")
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            BloodGlucoseConverter.convert("-5.5", "mmol")
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     @Throws(Exception::class)
     fun tooHigh() {
-        BloodGlucoseConverter.convert("1000", "mmol")
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            BloodGlucoseConverter.convert("1000", "mmol")
+        }
     }
 
 
-    @Test(expected = UnknownUnitException::class)
+    @Test
     @Throws(Exception::class)
     fun invalidUnit() {
-        BloodGlucoseConverter.convert("5.5", "what")
+        Assertions.assertThrows(UnknownUnitException::class.java) {
+            BloodGlucoseConverter.convert("5.5", "what")
+        }
     }
 
     @Test
@@ -76,12 +82,14 @@ class BloodGlucoseConverterTest {
 
         val expected = ConversionDTO(27.0, 1.5, 486.0)
 
-        Assert.assertEquals(actual, expected)
+        Assertions.assertEquals(actual, expected)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     @Throws(Exception::class)
     fun noInput() {
-        BloodGlucoseConverter.convert("", "")
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            BloodGlucoseConverter.convert("", "")
+        }
     }
 }

--- a/bot/src/test/java/com/dongtronic/diabot/util/DateTest.kt
+++ b/bot/src/test/java/com/dongtronic/diabot/util/DateTest.kt
@@ -1,7 +1,7 @@
 package com.dongtronic.diabot.util
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import java.sql.Timestamp
 
 class DateTest {
@@ -11,6 +11,6 @@ class DateTest {
         val timestamp = 1539672587884L
         val date = Timestamp(timestamp)
 
-        Assert.assertNotNull(date)
+        Assertions.assertNotNull(date)
     }
 }

--- a/bot/src/test/java/com/dongtronic/diabot/util/PatternsTest.kt
+++ b/bot/src/test/java/com/dongtronic/diabot/util/PatternsTest.kt
@@ -1,7 +1,7 @@
 package com.dongtronic.diabot.util
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 class PatternsTest {
 
@@ -12,10 +12,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -24,10 +24,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5.5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5.5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -36,10 +36,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100.5", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100.5", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -48,10 +48,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -60,10 +60,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -72,10 +72,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5.5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5.5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -84,10 +84,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100.5", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100.5", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -96,10 +96,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     /////
@@ -110,10 +110,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -122,10 +122,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5.5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5.5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -134,10 +134,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100.5", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100.5", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -146,10 +146,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -158,10 +158,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -170,10 +170,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5.5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5.5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -182,10 +182,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100.5", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100.5", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -194,10 +194,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -206,10 +206,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5.5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5.5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -218,10 +218,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -230,10 +230,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -242,10 +242,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100.5", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100.5", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -254,10 +254,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5.5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5.5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -266,10 +266,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("5", matcher.group(4))
-        Assert.assertEquals("mmol", matcher.group(5))
+        Assertions.assertEquals("5", matcher.group(4))
+        Assertions.assertEquals("mmol", matcher.group(5))
     }
 
     @Test
@@ -278,10 +278,10 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 
     @Test
@@ -290,9 +290,9 @@ class PatternsTest {
 
         val matcher = Patterns.unitBgPattern.matcher(message)
 
-        Assert.assertTrue(matcher.matches())
+        Assertions.assertTrue(matcher.matches())
 
-        Assert.assertEquals("100.5", matcher.group(4))
-        Assert.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals("100.5", matcher.group(4))
+        Assertions.assertEquals("mg", matcher.group(5))
     }
 }

--- a/bot/src/test/java/com/dongtronic/diabot/util/PatternsTest.kt
+++ b/bot/src/test/java/com/dongtronic/diabot/util/PatternsTest.kt
@@ -1,298 +1,85 @@
 package com.dongtronic.diabot.util
 
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 class PatternsTest {
 
 
-    @Test
-    fun unitStartNoSpacesMg() {
-        val message = "100mg"
+    @ParameterizedTest
+    @MethodSource("unitBgProvider")
+    fun unitBgPatternTest(data: BgParseData) {
+        val input = data.input
+        val expected = data.expected
+        val result = Patterns.unitBgPattern.matcher(input)
 
-        val matcher = Patterns.unitBgPattern.matcher(message)
+        Assertions.assertTrue(result.matches())
 
-        Assertions.assertTrue(matcher.matches())
+        val actualValue = result.group(4)
+        val actualUnit = result.group(5)
 
-        Assertions.assertEquals("100", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
+        Assertions.assertEquals(expected.value, actualValue)
+        Assertions.assertEquals(expected.unit, actualUnit)
     }
 
-    @Test
-    fun unitStartNoSpacesMmol() {
-        val message = "5.5mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5.5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun unitStartNoSpacesMgDecimal() {
-        val message = "100.5mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100.5", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun unitStartNoSpacesMmolWhole() {
-        val message = "5mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun unitStartSpacesMg() {
-        val message = "100 mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun unitStartSpacesMmol() {
-        val message = "5.5 mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5.5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun unitStartSpacesMgDecimal() {
-        val message = "100.5 mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100.5", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun unitStartSpacesMmolWhole() {
-        val message = "5 mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    /////
-
-    @Test
-    fun textStartNoSpacesMg() {
-        val message = "bla bla 100mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun textStartNoSpacesMmol() {
-        val message = "bla bla 5.5mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5.5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun textStartNoSpacesMgDecimal() {
-        val message = "bla bla 100.5mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100.5", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun textStartNoSpacesMmolWhole() {
-        val message = "bla bla 5mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun textStartSpacesMg() {
-        val message = "bla bla 100 mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun textStartSpacesMmol() {
-        val message = "bla bla 5.5 mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5.5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun textStartSpacesMgDecimal() {
-        val message = "bla bla 100.5 mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100.5", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun textStartSpacesMmolWhole() {
-        val message = "bla bla 5 mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun negativeNoSpacesMmol() {
-        val message = "-5.5mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5.5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun negativeNoSpacesMmolWhole() {
-        val message = "-5mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun negativeNoSpacesMg() {
-        val message = "-100mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun negativeNoSpacesMgDecimal() {
-        val message = "-100.5mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100.5", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun textStartNegativeMmol() {
-        val message = "bla bla -5.5mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5.5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun textStartNegativeMmolWhole() {
-        val message = "bla bla -5mmol"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("5", matcher.group(4))
-        Assertions.assertEquals("mmol", matcher.group(5))
-    }
-
-    @Test
-    fun textStartNegativeMg() {
-        val message = "bla bla -100mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
-
-    @Test
-    fun textStartNegativeMgDecimal() {
-        val message = "bla bla -100.5mg"
-
-        val matcher = Patterns.unitBgPattern.matcher(message)
-
-        Assertions.assertTrue(matcher.matches())
-
-        Assertions.assertEquals("100.5", matcher.group(4))
-        Assertions.assertEquals("mg", matcher.group(5))
-    }
+    private fun unitBgProvider() = Stream.of(
+            BgParseData(input = "100.5mg", expected = BgData("100.5", "mg")),
+            BgParseData(input = "100mg", expected = BgData("100", "mg")),
+            BgParseData(input = "5.5mmol", expected = BgData("5.5", "mmol")),
+            BgParseData(input = "5mmol", expected = BgData("5", "mmol")),
+
+            // spaces
+            BgParseData(input = "100.5 mg", expected = BgData("100.5", "mg")),
+            BgParseData(input = "100 mg", expected = BgData("100", "mg")),
+            BgParseData(input = "5.5 mmol", expected = BgData("5.5", "mmol")),
+            BgParseData(input = "5 mmol", expected = BgData("5", "mmol")),
+
+            // text
+            BgParseData(input = "bla bla 100.5mg", expected = BgData("100.5", "mg")),
+            BgParseData(input = "bla bla 100mg", expected = BgData("100", "mg")),
+            BgParseData(input = "bla bla 5.5mmol", expected = BgData("5.5", "mmol")),
+            BgParseData(input = "bla bla 5mmol", expected = BgData("5", "mmol")),
+
+            // text + spaces
+            BgParseData(input = "bla bla 100.5 mg", expected = BgData("100.5", "mg")),
+            BgParseData(input = "bla bla 100 mg", expected = BgData("100", "mg")),
+            BgParseData(input = "bla bla 5.5 mmol", expected = BgData("5.5", "mmol")),
+            BgParseData(input = "bla bla 5 mmol", expected = BgData("5", "mmol")),
+
+            // negative
+            BgParseData(input = "-100.5mg", expected = BgData("100.5", "mg")),
+            BgParseData(input = "-100mg", expected = BgData("100", "mg")),
+            BgParseData(input = "-5.5mmol", expected = BgData("5.5", "mmol")),
+            BgParseData(input = "-5mmol", expected = BgData("5", "mmol")),
+
+            // negative + spaces
+            BgParseData(input = "-100.5 mg", expected = BgData("100.5", "mg")),
+            BgParseData(input = "-100 mg", expected = BgData("100", "mg")),
+            BgParseData(input = "-5.5 mmol", expected = BgData("5.5", "mmol")),
+            BgParseData(input = "-5 mmol", expected = BgData("5", "mmol")),
+
+            // negative + text
+            BgParseData(input = "bla bla -100.5mg", expected = BgData("100.5", "mg")),
+            BgParseData(input = "bla bla -100mg", expected = BgData("100", "mg")),
+            BgParseData(input = "bla bla -5.5mmol", expected = BgData("5.5", "mmol")),
+            BgParseData(input = "bla bla -5mmol", expected = BgData("5", "mmol")),
+
+            // negative + text + spaces
+            BgParseData(input = "bla bla -100.5 mg", expected = BgData("100.5", "mg")),
+            BgParseData(input = "bla bla -100 mg", expected = BgData("100", "mg")),
+            BgParseData(input = "bla bla -5.5 mmol", expected = BgData("5.5", "mmol")),
+            BgParseData(input = "bla bla -5 mmol", expected = BgData("5", "mmol")),
+    )
+
+    data class BgData(
+            val value: String,
+            val unit: String
+    )
+
+    data class BgParseData(
+            val input: String,
+            val expected: BgData
+    )
 }

--- a/bot/src/test/java/com/dongtronic/diabot/util/PatternsTest.kt
+++ b/bot/src/test/java/com/dongtronic/diabot/util/PatternsTest.kt
@@ -13,12 +13,10 @@ class PatternsTest {
     fun unitBgPatternTest(data: BgParseData) {
         val input = data.input
         val expected = data.expected
-        val result = Patterns.unitBgPattern.matcher(input)
+        val result = Patterns.unitBgPattern.find(input)!!
 
-        Assertions.assertTrue(result.matches())
-
-        val actualValue = result.group(4)
-        val actualUnit = result.group(5)
+        val actualValue = result.groups["value"]!!.value
+        val actualUnit = result.groups["unit"]!!.value
 
         Assertions.assertEquals(expected.value, actualValue)
         Assertions.assertEquals(expected.unit, actualUnit)

--- a/bot/src/test/java/com/dongtronic/diabot/util/PatternsTest.kt
+++ b/bot/src/test/java/com/dongtronic/diabot/util/PatternsTest.kt
@@ -7,13 +7,63 @@ import java.util.stream.Stream
 
 class PatternsTest {
 
+    @ParameterizedTest
+    @MethodSource("inlineBgProvider")
+    fun inlineBgPatternTest(data: BgParseData) {
+        val input = data.input
+        val expected = data.expected
+        val result = Patterns.inlineBgPattern.find(input)
+
+        if (expected == null) {
+            Assertions.assertEquals(null, result)
+            return
+        }
+
+        Assertions.assertNotNull(result)
+
+        // result won't be null here because of the above assertion
+        result!!
+
+        val actualValue = result.groups["value"]!!.value
+
+        Assertions.assertEquals(expected.value, actualValue)
+    }
+
+    private fun inlineBgProvider() = Stream.of(
+            BgParseData(input = "test _100.5_", expected = BgData("100.5")),
+            BgParseData(input = "test _100_", expected = BgData("100")),
+            BgParseData(input = "test _5.5_", expected = BgData("5.5")),
+            BgParseData(input = "test _5_", expected = BgData("5")),
+
+            // invalid
+            BgParseData(input = "test _100.5 mg_", expected = null),
+            BgParseData(input = "test _100 mg_", expected = null),
+            BgParseData(input = "test _5.5 mmol_", expected = null),
+            BgParseData(input = "test _5 mmol_", expected = null),
+
+            // invalid + spaces
+            BgParseData(input = "test _100.5mg_", expected = null),
+            BgParseData(input = "test _100mg_", expected = null),
+            BgParseData(input = "test _5.5mmol_", expected = null),
+            BgParseData(input = "test _5mmol_", expected = null),
+    )
 
     @ParameterizedTest
     @MethodSource("unitBgProvider")
     fun unitBgPatternTest(data: BgParseData) {
         val input = data.input
         val expected = data.expected
-        val result = Patterns.unitBgPattern.find(input)!!
+        val result = Patterns.unitBgPattern.find(input)
+
+        if (expected == null) {
+            Assertions.assertEquals(null, result)
+            return
+        }
+
+        Assertions.assertNotNull(result)
+
+        // result won't be null here because of the above assertion
+        result!!
 
         val actualValue = result.groups["value"]!!.value
         val actualUnit = result.groups["unit"]!!.value
@@ -73,11 +123,11 @@ class PatternsTest {
 
     data class BgData(
             val value: String,
-            val unit: String
+            val unit: String? = null
     )
 
     data class BgParseData(
             val input: String,
-            val expected: BgData
+            val expected: BgData?
     )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,14 @@ allprojects {
         implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${kotlinCoroutinesVersion}"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${kotlinCoroutinesVersion}"
-        testImplementation group: 'junit', name: 'junit', version: "${junitVersion}"
+        testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: "${junitVersion}"
+        testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: "${junitVersion}"
         api group: 'org.slf4j', name: 'slf4j-api', version: "${slf4jVersion}"
+    }
+
+    test {
+        useJUnitPlatform()
+        systemProperty "junit.jupiter.testinstance.lifecycle.default", "per_class"
     }
 
     group = 'com.dongtronic.diabot'

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -718,7 +718,7 @@ style:
     excludedFunctions: 'equals'
     excludeLabeled: false
     excludeReturnFromLambda: true
-    excludeGuardClauses: false
+    excludeGuardClauses: true
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ shadowVersion = 6.1.0
 detektVersion = 1.18.1
 kotlinVersion = 1.5.31
 kotlinCoroutinesVersion = 1.5.2
-junitVersion = 4.12
+junitVersion = 5.8.2
 
 # Logging
 slf4jVersion = 1.7.25

--- a/nightscout-api/src/main/java/com/dongtronic/nightscout/Nightscout.kt
+++ b/nightscout-api/src/main/java/com/dongtronic/nightscout/Nightscout.kt
@@ -147,7 +147,7 @@ class Nightscout(baseUrl: String, token: String? = null) : Closeable {
                     // Set delta if the original is zero and the pebble endpoint is providing non-zero delta
                     || (dto.delta?.original == 0.0 && bgDelta.toDouble() != 0.0)) {
                 dto.deltaIsNegative = bgDelta.contains("-")
-                dto.delta = BloodGlucoseConverter.convert(bgDelta.replace("-".toRegex(), ""), dto.units)
+                dto.delta = BloodGlucoseConverter.convert(bgDelta.replace("-".toRegex(), ""), dto.units).getOrNull()
             }
             return@map dto
         }
@@ -190,15 +190,11 @@ class Nightscout(baseUrl: String, token: String? = null) : Closeable {
             val convertedBg = BloodGlucoseConverter.convert(sgv, "mg")
 
             if (delta.isNotEmpty()) {
-                try {
-                    val convertedDelta = BloodGlucoseConverter.convert(delta.replace("-".toRegex(), ""), "mg")
-                    dto.delta = convertedDelta
-                } catch (e: IllegalArgumentException) {
-                    // invalid delta
-                }
+                val convertedDelta = BloodGlucoseConverter.convert(delta.replace("-".toRegex(), ""), "mg")
+                dto.delta = convertedDelta.getOrNull()
             }
 
-            dto.glucose = convertedBg
+            dto.glucose = convertedBg.getOrThrow()
             dto.deltaIsNegative = delta.contains("-")
             dto.dateTime = Instant.ofEpochMilli(timestamp)
             dto.trend = trend

--- a/utilities/src/main/java/com/dongtronic/diabot/logic/diabetes/BloodGlucoseConverter.kt
+++ b/utilities/src/main/java/com/dongtronic/diabot/logic/diabetes/BloodGlucoseConverter.kt
@@ -2,12 +2,44 @@ package com.dongtronic.diabot.logic.diabetes
 
 import com.dongtronic.diabot.data.ConversionDTO
 import com.dongtronic.diabot.exceptions.UnknownUnitException
-import java.util.*
 
 /**
  * BG conversion logic
  */
 object BloodGlucoseConverter {
+
+    /**
+     * Get a set of appropriate unicode emojis for reacting to a blood glucose value.
+     *
+     * Currently, the two emojis are:
+     * :smirk: - 69 mg/dL or 6.9 mmol/L
+     * :100:   - 100 mg/dL, 5.5 mmol/L, or 10.0 mmol/L
+     */
+    fun getReactions(conversionDTO: ConversionDTO) = getReactions(conversionDTO.mmol, conversionDTO.mgdl)
+
+    /**
+     * Get a set of appropriate unicode emojis for reacting to a blood glucose value.
+     *
+     * Currently, the two emojis are:
+     * :smirk: - 69 mg/dL or 6.9 mmol/L
+     * :100:   - 100 mg/dL, 5.5 mmol/L, or 10.0 mmol/L
+     */
+    fun getReactions(mmol: Double, mgdl: Int): Set<String> {
+        val reactions = mutableSetOf<String>()
+        // #20: Reply with :smirk: when value is 69 mg/dL or 6.9 mmol/L
+        if (mmol == 6.9 || mgdl == 69) {
+            reactions.add("\uD83D\uDE0F")
+        }
+
+        // #36 and #60: Reply with :100: when value is 100 mg/dL, 5.5 mmol/L, or 10.0 mmol/L
+        if (mmol == 5.5
+                || mmol == 10.0
+                || mgdl == 100) {
+            reactions.add("\uD83D\uDCAF")
+        }
+
+        return reactions
+    }
 
     @Throws(UnknownUnitException::class)
     fun convert(value: String, unit: String?): ConversionDTO {

--- a/utilities/src/main/java/com/dongtronic/diabot/logic/diabetes/BloodGlucoseConverter.kt
+++ b/utilities/src/main/java/com/dongtronic/diabot/logic/diabetes/BloodGlucoseConverter.kt
@@ -14,6 +14,10 @@ object BloodGlucoseConverter {
      * Currently, the two emojis are:
      * :smirk: - 69 mg/dL or 6.9 mmol/L
      * :100:   - 100 mg/dL, 5.5 mmol/L, or 10.0 mmol/L
+     *
+     * @param conversionDTO BG conversion DTO
+     * @return [Set] of unicode emojis reacting to the given BG
+     * @see [getReactions]
      */
     fun getReactions(conversionDTO: ConversionDTO) = getReactions(conversionDTO.mmol, conversionDTO.mgdl)
 
@@ -23,6 +27,10 @@ object BloodGlucoseConverter {
      * Currently, the two emojis are:
      * :smirk: - 69 mg/dL or 6.9 mmol/L
      * :100:   - 100 mg/dL, 5.5 mmol/L, or 10.0 mmol/L
+     *
+     * @param mmol BG number in mmol/L
+     * @param mgdl BG number in mg/dL
+     * @return [Set] of unicode emojis reacting to the given BG
      */
     fun getReactions(mmol: Double, mgdl: Int): Set<String> {
         val reactions = mutableSetOf<String>()
@@ -41,13 +49,22 @@ object BloodGlucoseConverter {
         return reactions
     }
 
-    @Throws(UnknownUnitException::class)
-    fun convert(value: String, unit: String?): ConversionDTO {
+    /**
+     * Convert a string blood glucose input into a [ConversionDTO].
+     *
+     * @param value BG number
+     * @param unit Optional: Measurement unit of [value]
+     * @return [ConversionDTO] if successful
+     * @throws IllegalArgumentException if [value] is not numeric
+     * @throws IllegalArgumentException if [value] is not between 0 and 999
+     * @throws UnknownUnitException if [unit] is an unknown BG measurement unit
+     */
+    fun convert(value: String, unit: String?): Result<ConversionDTO> {
         val input = value.toDoubleOrNull()
-                ?: throw IllegalArgumentException("value must be numeric")
+                ?: return Result.failure(IllegalArgumentException("value must be numeric"))
 
         if (input < 0 || input > 999) {
-            throw IllegalArgumentException("value must be between 0 and 999")
+            return Result.failure(IllegalArgumentException("value must be between 0 and 999"))
         }
 
         return if (unit != null && unit.length > 1) {
@@ -57,7 +74,7 @@ object BloodGlucoseConverter {
         }
     }
 
-    private fun convert(originalValue: Double): ConversionDTO {
+    private fun convert(originalValue: Double): Result<ConversionDTO> {
         return when {
             originalValue < 25 -> convert(originalValue, GlucoseUnit.MMOL)
             originalValue > 50 -> convert(originalValue, GlucoseUnit.MGDL)
@@ -65,43 +82,38 @@ object BloodGlucoseConverter {
         }
     }
 
-    @Throws(UnknownUnitException::class)
-    private fun convert(originalValue: Double, unit: String): ConversionDTO {
-
+    private fun convert(originalValue: Double, unit: String): Result<ConversionDTO> {
         return when {
-            unit.uppercase().contains("MMOL") -> {
+            unit.contains("MMOL", true) -> {
                 val result = originalValue * 18.016
-                ConversionDTO(originalValue, result, GlucoseUnit.MMOL)
+                Result.success(ConversionDTO(originalValue, result, GlucoseUnit.MMOL))
             }
-            unit.uppercase().contains("MG") -> {
+            unit.contains("MG", true) -> {
                 val result = originalValue / 18.016
-                ConversionDTO(originalValue, result, GlucoseUnit.MGDL)
+                Result.success(ConversionDTO(originalValue, result, GlucoseUnit.MGDL))
             }
-            else -> throw UnknownUnitException()
+            else -> Result.failure(UnknownUnitException())
         }
     }
 
-    private fun convert(originalValue: Double, unit: GlucoseUnit): ConversionDTO {
-
+    private fun convert(originalValue: Double, unit: GlucoseUnit): Result<ConversionDTO> {
         return when (unit) {
             GlucoseUnit.MMOL -> {
                 val result = originalValue * 18.016
-                ConversionDTO(originalValue, result, GlucoseUnit.MMOL)
+                Result.success(ConversionDTO(originalValue, result, GlucoseUnit.MMOL))
             }
             GlucoseUnit.MGDL -> {
                 val result = originalValue / 18.016
-                ConversionDTO(originalValue, result, GlucoseUnit.MGDL)
+                Result.success(ConversionDTO(originalValue, result, GlucoseUnit.MGDL))
             }
-            GlucoseUnit.AMBIGUOUS -> {
-                return convertAmbiguous(originalValue)
-            }
+            GlucoseUnit.AMBIGUOUS -> convertAmbiguous(originalValue)
         }
     }
 
-    private fun convertAmbiguous(originalValue: Double): ConversionDTO {
+    private fun convertAmbiguous(originalValue: Double): Result<ConversionDTO> {
         val toMgdl = originalValue * 18.016
         val toMmol = originalValue / 18.016
 
-        return ConversionDTO(originalValue, toMmol, toMgdl)
+        return Result.success(ConversionDTO(originalValue, toMmol, toMgdl))
     }
 }


### PR DESCRIPTION
For some reason, the multiple inline conversion logic introduced by @Adidushi stopped working at some point. I didn't investigate why it wasn't working but I instead opted to clean up the code. This was a pretty overkill fix, but I've been wanting to refactor the conversion code for a while so I took this opportunity to do so. 

- Upgraded to JUnit 5 (mainly for parameterized tests)
- Converted existing blood glucose pattern tests to parameterized
- Added tests for inline blood glucose pattern
- Redone unit and inline BG patterns. The main thing I was trying to accomplish was to not match the entire message. Instead, these patterns only match the parts of the message that are relevant (eliminating the need to do recursion with searching for multiple BG units in a message). I also added support for named groups to make it easier to follow the accompanying code.
- Changed style of multiple conversions to make the results easier to read
- Added unicode tree characters to the ambiguous unit result (to 'link' the results together) and improve readability
- Remove usage of checked exceptions/throwing exceptions with BG and A1c conversion functions, instead opting for Kotlin's `Result` type to indicate success or failure of conversion. This improves code readability slightly with the lack of try-catch blocks.
- Add documentation to BG and A1c conversion functions