### PR TITLE
Customizable graph time periods

### DIFF
--- a/bg-graph/src/main/java/com/dongtronic/diabot/graph/GraphSettings.kt
+++ b/bg-graph/src/main/java/com/dongtronic/diabot/graph/GraphSettings.kt
@@ -7,6 +7,7 @@ import java.awt.Color
 data class GraphSettings (
         val plotMode: PlottingStyle = PlottingStyle.SCATTER,
         val theme: GraphTheme = GraphTheme.DARK,
+        val hours: Long = 4,
         // for dark theme
         val highDarkColor: Color = Color(255, 140, 0),
         val inRangeDarkColor: Color = Color(0, 203, 255),

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutApplicationCommand.kt
@@ -138,7 +138,7 @@ class NightscoutApplicationCommand : ApplicationCommand {
                 .subscribe({
                     event.reply("Plotting style changed to `${it.plotMode.name}`").setEphemeral(true).queue()
                 }, {
-                    event.reply("Could not update plotting style: ${it.javaClass.simpleName}")
+                    replyError(event, it, "Could not update plotting style: ${it.javaClass.simpleName}")
                     logger.warn("Unexpected error when changing graph mode for ${event.user}", it)
                 })
     }

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutApplicationCommand.kt
@@ -26,6 +26,7 @@ class NightscoutApplicationCommand : ApplicationCommand {
     private val commandModePrivacy = "privacy"
     private val commandModeGlobalPrivacy = "globalprivacy"
     private val commandModeGraphMode = "graphmode"
+    private val commandModeGraphHours = "graphhours"
     private val commandArgUrl = "url"
     private val commandArgToken = "token"
     private val commandArgPrivacy = "privacy"
@@ -35,6 +36,8 @@ class NightscoutApplicationCommand : ApplicationCommand {
     private val commandArgMode = "mode"
     private val commandArgScatter = "scatter"
     private val commandArgLine = "line"
+
+    private val commandArgHours = "hours"
 
     private val commandButtonDeleteConfirm = "nsdeleteyes"
     private val commandButtonDeleteCancel = "nsdeleteno"
@@ -50,6 +53,7 @@ class NightscoutApplicationCommand : ApplicationCommand {
                 commandModePrivacy -> setPrivacy(event)
                 commandModeGlobalPrivacy -> setGlobalPrivacy(event)
                 commandModeGraphMode -> setGraphMode(event)
+                commandModeGraphHours -> setGraphHours(event)
             }
             groupNameClear -> when (event.subcommandName) {
                 commandModeToken -> clearToken(event)
@@ -139,6 +143,26 @@ class NightscoutApplicationCommand : ApplicationCommand {
                 })
     }
 
+    private fun setGraphHours(event: SlashCommandEvent) {
+        val hours = event.getOption(commandArgHours)!!.asLong
+
+        if (hours < 1 || hours > 24) {
+            event.reply("The number of hours must be between 1 and 24").setEphemeral(true).queue()
+            return
+        }
+
+        NightscoutDAO.instance.getUser(event.user.id)
+                .map { it.graphSettings.copy(hours = hours) }
+                .flatMap { NightscoutDAO.instance.updateGraphSettings(event.user.id, it) }
+                .subscribe({
+                    val plural = if (it.hours == 1L) "s" else ""
+                    event.reply("Your future graphs will now display ${it.hours} hour$plural of data").setEphemeral(true).queue()
+                }, {
+                    replyError(event, it, "Could not change the graph hours: ${it.javaClass.simpleName}")
+                    logger.warn("Unexpected error when changing graph hours for ${event.user}", it)
+                })
+    }
+
     private fun clearToken(event: SlashCommandEvent) {
         NightscoutFacade.clearToken(event.user).subscribe({
             event.reply("Your Nightscout token has been deleted").setEphemeral(true).queue()
@@ -222,7 +246,10 @@ class NightscoutApplicationCommand : ApplicationCommand {
                         SubcommandData(commandModeGraphMode, "Set the plotting style for Nightscout graphs")
                                 .addOptions(OptionData(OptionType.STRING, commandArgMode, "Plotting style", true)
                                         .addChoice(commandArgScatter, commandArgScatter)
-                                        .addChoice(commandArgLine, commandArgLine))
+                                        .addChoice(commandArgLine, commandArgLine)),
+                        SubcommandData(commandModeGraphHours, "Set the number of hours displayed in Nightscout graphs")
+                                .addOptions(OptionData(OptionType.INTEGER, commandArgHours, "Hours", true))
+
                 ),
                 SubcommandGroupData(groupNameClear, "Clear Nightscout settings").addSubcommands(
                         SubcommandData(commandModeUrl, "Clear Nightscout url"),


### PR DESCRIPTION
Features:
- Optional argument on the `/graph` command to change the number of hours displayed for that graph only. If not provided, this defaults to the number of hours set in the user's graph settings, or 4 hours if that also is not set.
- Setting for the default graph hours via `/nightscout set graphhours`. The default is 4 hours.

Fixes:
- Error message never being sent with `/nightscout set graphmode`