### PR TITLE
Fix graph hour setting message grammar

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutApplicationCommand.kt
@@ -155,7 +155,7 @@ class NightscoutApplicationCommand : ApplicationCommand {
                 .map { it.graphSettings.copy(hours = hours) }
                 .flatMap { NightscoutDAO.instance.updateGraphSettings(event.user.id, it) }
                 .subscribe({
-                    val plural = if (it.hours == 1L) "s" else ""
+                    val plural = if (it.hours != 1L) "s" else ""
                     event.reply("Your future graphs will now display ${it.hours} hour$plural of data").setEphemeral(true).queue()
                 }, {
                     replyError(event, it, "Could not change the graph hours: ${it.javaClass.simpleName}")


### PR DESCRIPTION
Super small fix for the `Your future graphs will now display X hour(s) of data` message. The plurality of `hour` was inverted, so 1 hour gave: 
`Your future graphs will now display 1 hours of data`

And 2 hours gave:
`Your future graphs will now display 2 hour of data`