### PR TITLE
Don't convert detected BG values in diabot commands

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/Main.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/Main.kt
@@ -34,7 +34,7 @@ import java.util.*
 import javax.security.auth.login.LoginException
 
 object Main {
-    private var debug = false
+    private val debug = System.getenv("DIABOT_DEBUG") != null
 
     @Throws(LoginException::class)
     @JvmStatic
@@ -65,12 +65,8 @@ object Main {
 
 
         // sets the bot prefix
-        if (System.getenv("DIABOT_DEBUG") != null) {
-            client.setPrefix("dl ")
-            debug = true
-        } else {
-            client.setPrefix("diabot ")
-        }
+        val prefix = if (debug) "dl " else "diabot "
+        client.setPrefix(prefix)
 
         client.setOwnerId("189436077793083392") // Cas
         client.setCoOwnerIds("125616270254014464", "319371513159614464") // Adi, Garlic

--- a/bot/src/main/java/com/dongtronic/diabot/Main.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/Main.kt
@@ -127,7 +127,7 @@ object Main {
                 .addEventListeners(
                         waiter,
                         builtClient,
-                        ConversionListener(),
+                        ConversionListener(prefix),
                         RewardListener(),
                         UsernameEnforcementListener(),
                         OhNoListener(),

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ConversionListener.kt
@@ -8,7 +8,7 @@ import com.dongtronic.diabot.util.logger
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 
-class ConversionListener : ListenerAdapter() {
+class ConversionListener(private val prefix: String) : ListenerAdapter() {
     private val logger = logger()
 
     companion object {
@@ -19,6 +19,7 @@ class ConversionListener : ListenerAdapter() {
 
     override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
         if (event.author.isBot) return
+        if (event.message.contentRaw.startsWith(prefix, true)) return
 
         val message = event.message
         val messageText = stripMonospace(message.contentRaw)


### PR DESCRIPTION
When entering a BG value (or a value that could be seen as a BG value with the `<number> <BG unit>` format) as an argument to a Diabot command, the bot will respond with a BG conversion *and* respond with the command's output.

For example:
1. `diabot estimate average 50 mmol`
	- Diabot: `50.0 mmol/L is 901 mg/dL`
	- Diabot: `An A1c of 6.7% (DCCT) or 50.0 mmol/mol (IFCC) is about 146 mg/dL or 8.1 mmol/L`
2. `diabot estimate a1c 5 mmol`
	- Diabot: `5.0 mmol/L is 90 mg/dL`
	- Diabot: `An average of 5.0 mmol/L is about 4.8% (DCCT) or 28.6 mmol/mol (IFCC)`
3. `diabot estimate a1c 150 mgdl`
	- Diabot: `150 mg/dL is 8.3 mmol/L`
	- Diabot: `An average of 150 mg/dL is about 6.9% (DCCT) or 51.4 mmol/mol (IFCC)`
4. `diabot convert 5 mmol`
	- Diabot: `5.0 mmol/L is 90 mg/dL`
	- Diabot: `5.0 mmol/L is 90 mg/dL`

This PR prevents the conversion listener from running on messages that have Diabot's command prefix, making the above situations only respond with the second message of each (which is the executed command's output). 