### PR TITLE
Quote lookup by user ID

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteCommand.kt
@@ -20,7 +20,12 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
         this.help = "Gets saved quotes"
         this.guildOnly = true
         this.aliases = arrayOf("q")
-        this.examples = arrayOf("diabot quote", "diabot quote 1337", "diabot quote @Cas")
+        this.examples = arrayOf(
+                "diabot quote",
+                "diabot quote 1337",
+                "diabot quote @Cas",
+                "diabot quote 795873471530926100"
+        )
         this.children = arrayOf(
                 QuoteAddCommand(category, this),
                 QuoteDeleteCommand(category, this),
@@ -39,9 +44,16 @@ class QuoteCommand(category: Category) : DiscordCommand(category, null) {
                 getRandomQuote(event.guild.id, QuoteDTO::authorId eq member.id)
             }
             args.isNotEmpty() -> {
-                if (args.all { it.toLongOrNull() != null }) {
-                    // may be a quote id
-                    QuoteDAO.getInstance().getQuote(event.guild.id, args[0])
+                val arg = args[0]
+                if (arg.toLongOrNull() != null) {
+                    if (arg.length < 17) {
+                        // the first discord snowflakes were 17 digits long
+                        // assume it's a quote ID if it's less than 17 digits long
+                        QuoteDAO.getInstance().getQuote(event.guild.id, arg)
+                    } else {
+                        // assume it's a user ID otherwise
+                        getRandomQuote(event.guild.id, QuoteDTO::authorId eq arg)
+                    }
                 } else {
                     // may be a username
                     val joined = args.joinToString(" ")


### PR DESCRIPTION
This PR allows quotes to be looked up by using a user's snowflake:
`diabot quote 795873471530926100`
`.q 795873471530926100`

This produces the same result as the existing "lookup by mention" feature, but it removes the requirement to ping the user for each quote lookup (which can be annoying when looking through the quotes of another user).

The first Discord snowflakes were 17 digits long. Technically they can be as short as 7 digits, but they reached 17 digits in length less than a month after Discord epoch (`2015-01-28 14:16:25.791Z`). The snowflake length was still 17 digits at the time Discord launched in May 2015, so it's safe to assume that 17 digits is the minimum length a real Discord snowflake can be.

Quote lookup already uses numbers for the quote IDs, so to accommodate for user IDs I went with the assumption that quote IDs would not reach 17 digits long anytime soon:
- If the number argument is less than 17 digits, assume it's a quote ID
- Otherwise, assume it's a user ID