### PR TITLE
Fix graphing when an entry is outside of the allowed conversion range

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutGraphApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutGraphApplicationCommand.kt
@@ -137,7 +137,7 @@ class NightscoutGraphApplicationCommand : ApplicationCommand {
                             .find("date", startTime, MongoOperator.gte)
                             .count(count)
                             .toMap()
-                    ns.getSgv(params = findParam)
+                    ns.getSgv(params = findParam, throwOnConversion = false)
                             // duplicate code from NightscoutCommand. will be cleaned up later with a refactor of both
                             .onErrorMap({ error ->
                                 error is HttpException


### PR DESCRIPTION
If a user's nightscout contains an entry that is outside the `-999 <= sgv <= 999` range, executing `/graph` while that entry is in the hour range specified will make the command only return `Error: value must be between -999 and 999`. 

Until the erroneous entry/entries are either removed manually, or the entry/entries are older than the hour value specified, `/graph` is effectively broken for them. This PR makes the `/graph` command ignore entries outside of the allowed range, restoring the graphing functionality despite having erroneous entries.