### PR TITLE
Bump JDA to v5.0.0-alpha.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ reactorCoreVersion = 3.3.8.RELEASE
 reactorKotlinVersion = 1.0.2.RELEASE
 
 # JDA
-jdaVersion = 5.0.0-alpha.20
+jdaVersion = 5.0.0-alpha.21
 jdaChewtilsVersion = 2.0-SNAPSHOT
 jdaKtxVersion = fc7d7de
 


### PR DESCRIPTION
JDA-Chewtils updated to JDA 5 alpha 21 which includes some breaking changes regarding gateway session and voice events. We don't use any of those events in our code, but Chewtils does which means we have to bump the JDA version alongside Chewtils (as Chewtils doesn't have provide proper versioning for the JDA 5 branch besides `-SNAPSHOT`).