### PR TITLE
Remove token query param when setting nightscout url

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSetCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSetCommand.kt
@@ -51,7 +51,7 @@ class NightscoutAdminSetCommand(category: Category, parent: Command?) : DiscordC
                 event.message.mentions.users[0]
             }
 
-            val url = NightscoutFacade.validateNightscoutUrl(args[1])
+            val url = NightscoutFacade.parseNightscoutUrl(args[1]).first
 
             logger.info("Admin setting URL for user ${args[0]} to ${args[1]}")
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSetCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutAdminSetCommand.kt
@@ -1,7 +1,6 @@
 package com.dongtronic.diabot.platforms.discord.commands.nightscout
 
 import com.dongtronic.diabot.authorName
-import com.dongtronic.diabot.data.mongodb.NightscoutDAO
 import com.dongtronic.diabot.nameOf
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.platforms.discord.logic.NightscoutFacade
@@ -51,11 +50,9 @@ class NightscoutAdminSetCommand(category: Category, parent: Command?) : DiscordC
                 event.message.mentions.users[0]
             }
 
-            val url = NightscoutFacade.parseNightscoutUrl(args[1]).first
-
             logger.info("Admin setting URL for user ${args[0]} to ${args[1]}")
 
-            NightscoutDAO.instance.setUrl(user.id, url).subscribe({
+            NightscoutFacade.setUrl(user, args[1]).subscribe({
                 event.reply("Admin set Nightscout URL for ${event.nameOf(user)} [requested by ${event.authorName}]")
             }, {
                 val msg = "Could not set Nightscout URL for ${event.nameOf(user)} (${user.id})"

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutCommand.kt
@@ -141,7 +141,7 @@ class NightscoutCommand(category: Category) : DiscordCommand(category, null) {
 
             args.isNotEmpty() && args[0].matches("^https?://.*".toRegex()) -> {
                 // is a URL
-                val url = NightscoutFacade.validateNightscoutUrl(args[0])
+                val url = NightscoutFacade.parseNightscoutUrl(args[0]).first
                 getDataFromDomain(url, event)
             }
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/logic/NightscoutFacade.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/logic/NightscoutFacade.kt
@@ -60,6 +60,13 @@ object NightscoutFacade {
             finalUrl = "https://$finalUrl"
         }
 
+        finalUrl = finalUrl
+                .toHttpUrl()
+                .newBuilder()
+                .removeAllQueryParameters("token")
+                .build()
+                .toString()
+
         if (finalUrl.endsWith("/")) {
             finalUrl = finalUrl.trimEnd('/')
         }

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/logic/NightscoutFacade.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/logic/NightscoutFacade.kt
@@ -17,10 +17,10 @@ object NightscoutFacade {
     }
 
     fun setUrl(user: User, url: String): Mono<UpdateResult> {
-        val finalUrl = validateNightscoutUrl(url)
-        var update = NightscoutDAO.instance.setUrl(user.id, finalUrl)
+        val finalUrl = parseNightscoutUrl(url)
+        var update = NightscoutDAO.instance.setUrl(user.id, finalUrl.first)
 
-        val token = url.toHttpUrl().queryParameter("token")
+        val token = finalUrl.second
         if (token != null) {
             update = update.flatMap { setToken(user, token) }
         }
@@ -53,28 +53,31 @@ object NightscoutFacade {
         return NightscoutDAO.instance.getUser(user.id)
     }
 
-    fun validateNightscoutUrl(url: String): String {
-        var finalUrl = url
-        if (!finalUrl.contains("http://") && !finalUrl.contains("https://")) {
-            logger.info("Missing scheme in Nightscout URL: $finalUrl, adding https://")
-            finalUrl = "https://$finalUrl"
+    fun parseNightscoutUrl(url: String): Pair<String, String?> {
+        var inputUrl = url
+        if (!url.startsWith("http://", ignoreCase = true) && !url.startsWith("https://", ignoreCase = true)) {
+            logger.debug("Missing scheme in Nightscout URL: $inputUrl, adding https://")
+            inputUrl = "https://$inputUrl"
         }
 
-        finalUrl = finalUrl
-                .toHttpUrl()
-                .newBuilder()
-                .removeAllQueryParameters("token")
-                .build()
-                .toString()
+        val parsed = inputUrl.toHttpUrl()
+        val final = parsed.newBuilder()
+        val token = parsed.queryParameter("token")
+        // trim token
+        final.removeAllQueryParameters("token")
+        logger.debug("Input: $final")
 
-        if (finalUrl.endsWith("/")) {
-            finalUrl = finalUrl.trimEnd('/')
+        val pathSegments = parsed.pathSegments.dropLastWhile { it == "" }
+        if (pathSegments.takeLast(2) == listOf("api", "v1")) {
+            logger.debug("Removing API declaration in NS URL path: $pathSegments")
+            val trimmedPath = pathSegments.dropLast(2).joinToString("/")
+            // reset the path to nothing
+            final.encodedPath("/")
+            final.addPathSegments(trimmedPath)
         }
 
-        if (finalUrl.endsWith("/api/v1")) {
-            finalUrl = finalUrl.removeSuffix("/api/v1")
-        }
+        logger.debug("Final URL: $final")
 
-        return finalUrl
+        return final.toString() to token
     }
 }


### PR DESCRIPTION
Ensures that nobody except diabot has access to the token once it's set