### PR TITLE
Update JDA to 5.0.0-beta.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,9 @@ reactorCoreVersion = 3.3.8.RELEASE
 reactorKotlinVersion = 1.0.2.RELEASE
 
 # JDA
-jdaVersion = 5.0.0-alpha.21
+jdaVersion = 5.0.0-beta.2
 jdaChewtilsVersion = 2.0-SNAPSHOT
-jdaKtxVersion = 0.9.5-alpha.19
+jdaKtxVersion = 0.10.0-beta.1
 
 # Parsing
 romeVersion = 1.11.1


### PR DESCRIPTION
Bumps JDA to `5.0.0-beta.2` and jda-ktx to `0.10.0-beta.1`