### PR TITLE
Fix incorrect quote lookups when replying with pings enabled

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,9 @@ reactorCoreVersion = 3.3.8.RELEASE
 reactorKotlinVersion = 1.0.2.RELEASE
 
 # JDA
-jdaVersion = 5.0.0-alpha.21
+jdaVersion = 5.0.0-beta.2
 jdaChewtilsVersion = 2.0-SNAPSHOT
-jdaKtxVersion = 0.9.5-alpha.19
+jdaKtxVersion = 0.10.0-beta.1
 
 # Parsing
 romeVersion = 1.11.1


### PR DESCRIPTION
When executing the `diabot quote` command while responding to another message with the ping option enabled, Diabot will ignore any arguments given and prioritize the user mentioned with the reply as an 'argument'.

Expected:
```
Person 1: does anyone have a funny quote?
Person 2 (replying to Person 1's message with the ping option enabled): diabot quote 200
Diabot: [looks up quote number 200]
```

Actual:
```
Person 1: does anyone have a funny quote?
Person 2 (replying to Person 1's message with the ping option enabled): diabot quote 200
Diabot: [looks up a random quote belonging to Person 1]
```

The reason for this because of how mentions are currently handled in the quote command. In an attempt to avoid unnecessary argument parsing for `diabot quote @discord_user_mention`, the original code checked for mentioned users in the message with `Message.mentions.members` instead of manually parsing for mentions. This API also includes mentioned users as part of a reply which makes Diabot look up quotes created by the user being replied to, instead of parsing the actual arguments.

This PR fixes this issue by manually parsing for mentions in the argument instead of using the `Message.mentions.members` API.