### PR TITLE
Track quote creators

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDTO.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/data/mongodb/QuoteDTO.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
  * @property channelId the channel which this quote is located under
  * @property author the quote's author
  * @property authorId the author's user ID
+ * @property quoterId the user ID of the person who created the quote
  * @property message the quote message
  * @property messageId the quote's message ID
  * @property time quote creation in unix time
@@ -20,6 +21,7 @@ data class QuoteDTO(
         val channelId: String,
         val author: String,
         val authorId: String = "",
+        val quoterId: String = "",
         val message: String,
         val messageId: String,
         val time: Long = System.currentTimeMillis() / 1000

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -59,6 +59,7 @@ class QuoteAddCommand(category: Category, parent: QuoteCommand) : DiscordCommand
                         channelId = event.channel.id,
                         author = author,
                         authorId = authorId.toString(),
+                        quoterId = event.author.id,
                         message = message,
                         messageId = event.message.id
                 )

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteDeleteCommand.kt
@@ -40,7 +40,7 @@ class QuoteDeleteCommand(category: Category, parent: Command) : DiscordCommand(c
 
         if (!event.member.hasPermission(Permission.MESSAGE_MANAGE)) {
             execution = QuoteDAO.getInstance().getQuote(event.guild.id, quoteId.toString()).flatMap {
-                if (it.authorId == event.author.id) {
+                if (it.authorId == event.author.id || it.quoterId == event.author.id) {
                     // this will be mapped to the delete command
                     it.toMono()
                 } else {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -57,14 +57,15 @@ class QuoteListener(private val client: CommandClient) : CoroutineEventListener 
 
         val quoteMessage = Consumer<Message> { message ->
             QuoteDAO.getInstance().addQuote(
-                QuoteDTO(
-                    guildId = guild.id,
-                    channelId = event.guildChannel.id,
-                    author = message.author.name,
-                    authorId = message.author.id,
-                    message = message.contentRaw,
-                    messageId = message.id
-            )
+                    QuoteDTO(
+                            guildId = guild.id,
+                            channelId = event.guildChannel.id,
+                            author = message.author.name,
+                            authorId = message.author.id,
+                            quoterId = event.userId,
+                            message = message.contentRaw,
+                            messageId = message.id
+                    )
             ).subscribe({
                 message.addReaction(speechEmoji).queue()
                 reply { event.guildChannel.sendMessage(QuoteAddCommand.createAddedMessage(author.asMention, it.quoteId!!, message.jumpUrl)) }

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -9,17 +9,14 @@ import com.jagrosh.jdautilities.command.CommandClient
 import com.jagrosh.jdautilities.command.CommandEvent
 import dev.minn.jda.ktx.coroutines.await
 import dev.minn.jda.ktx.events.CoroutineEventListener
-import net.dv8tion.jda.api.entities.Message
+import kotlinx.coroutines.reactive.awaitFirstOrNull
 import net.dv8tion.jda.api.entities.MessageType
 import net.dv8tion.jda.api.entities.emoji.Emoji
 import net.dv8tion.jda.api.entities.emoji.UnicodeEmoji
 import net.dv8tion.jda.api.events.GenericEvent
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent
-import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
 import org.litote.kmongo.eq
-import reactor.kotlin.core.publisher.toMono
-import java.util.function.Consumer
 
 class QuoteListener(private val client: CommandClient) : CoroutineEventListener {
     private val quoteCommand: QuoteCommand = client.commands.filterIsInstance(QuoteCommand::class.java).first()
@@ -35,60 +32,58 @@ class QuoteListener(private val client: CommandClient) : CoroutineEventListener 
         }
     }
 
+    @Suppress("CyclomaticComplexMethod", "ReturnCount")
     private suspend fun onMessageReactionAdd(event: MessageReactionAddEvent) {
-        if (event.retrieveUser().await().isBot) return
         if (!event.isFromGuild) return
-        if (event.reaction.emoji !is UnicodeEmoji) return
-        if (event.reaction.emoji != speechEmoji) return
+        if (event.reaction.emoji !is UnicodeEmoji || event.reaction.emoji != speechEmoji) return
+
+        val reactor = event.retrieveMember().await()
+
+        if (reactor.user.isBot) return
         if (!QuoteDAO.checkRestrictions(event.guildChannel)) return
 
         val message = event.retrieveMessage().await()
-        val author = event.retrieveMember().await()
-        val guild = event.guild
 
+        if (message.author.isBot) return
+        if (message.type != MessageType.DEFAULT && message.type != MessageType.INLINE_REPLY) return
         // Ignore event if the bot already created a quote from this message
         if (message.reactions.any { it.emoji == speechEmoji && it.isSelf }) return
 
-        /**
-         * Replies to the channel only if the reacting user has permission to send messages
-         */
-        val reply: (() -> MessageCreateAction) -> Unit = { msg ->
-            if (event.guildChannel.canTalk(author)) {
-                msg().queue()
-            }
+        // Only add quote if there are no quotes with the message ID
+        try {
+            val quote = QuoteDAO.getInstance().getQuotes(event.guild.id, QuoteDTO::messageId eq event.messageId).awaitFirstOrNull()
+            if (quote != null) return
+        } catch (_: NoSuchElementException) {
         }
 
-        val quoteMessage = Consumer<Message> { msg ->
+        val quote = try {
             QuoteDAO.getInstance().addQuote(
                     QuoteDTO(
-                            guildId = guild.id,
+                            guildId = event.guild.id,
                             channelId = event.guildChannel.id,
-                            author = msg.author.name,
-                            authorId = msg.author.id,
-                            quoterId = event.userId,
-                            message = msg.contentRaw,
-                            messageId = msg.id
+                            author = message.author.name,
+                            authorId = message.author.id,
+                            quoterId = reactor.id,
+                            message = message.contentRaw,
+                            messageId = message.id
                     )
-            ).subscribe({
-                msg.addReaction(speechEmoji).queue()
-                reply { event.guildChannel.sendMessage(QuoteAddCommand.createAddedMessage(author.asMention, it.quoteId!!, msg.jumpUrl)) }
-            }, {
-                reply { event.guildChannel.sendMessage("Could not create quote for message: ${msg.id}") }
-            })
+            ).awaitFirstOrNull()
+        } catch (_: Exception) {
+            null
         }
 
-        QuoteDAO.getInstance()
-                // search for any quotes with this message ID
-                .getQuotes(guild.id, QuoteDTO::messageId eq event.messageId)
-                .toMono()
-                .subscribe({ /*ignored*/ }, { error ->
-                    // only add quote if there are no quotes matching the reacted message ID
-                    if (error is NoSuchElementException) {
-                        message.toMono()
-                                .filter { (it.type == MessageType.DEFAULT || it.type == MessageType.INLINE_REPLY) && !it.author.isBot }
-                                .subscribe(quoteMessage)
-                    }
-                })
+        if (quote != null) {
+            message.addReaction(speechEmoji).await()
+        }
+
+        // Don't reply if the reacting user doesn't have permission to send messages in the channel
+        if (!event.guildChannel.canTalk(reactor)) return
+
+        if (quote != null) {
+            event.guildChannel.sendMessage(QuoteAddCommand.createAddedMessage(reactor.asMention, quote.quoteId!!, message.jumpUrl)).await()
+        } else {
+            event.guildChannel.sendMessage("Could not create quote for message: ${message.id}").await()
+        }
     }
 
     private fun onMessageReceived(event: MessageReceivedEvent) {


### PR DESCRIPTION
- Adds a new field to quote objects containing the creator of it
	- A quote creator is the person who added the first 💬 reaction, or ran `diabot quote add`
	- A quote author is the person whose message was quoted (either via a 💬 reaction on their message, or someone running `diabot quote add "something" - @theirname`)
- Allows quote creators to delete quotes they quoted (using the new quote creator field)
- Fixes an issue where deleted quotes could be re-quoted
	- Most quotes are added via the 💬 reaction, but deleting a quote doesn't remove the existing reactions on the message. If someone clicks/taps on the existing speech bubble reaction under a message which *was* quoted (but was deleted), it will re-quote the message.
	- It's not exactly a bug, but I would classify this as unintended behavior. If a quote was deleted, it was likely deleted for a reason and I don't see a reason why it would need to be re-quoted.
	- This is fixed by checking for a 💬 reaction by Diabot on the message before quoting it. Using this approach, mods can easily override the quote block on that message by removing Diabot's reaction if it's deemed necessary.
- Refactors the quote listener to be cleaner by using async code instead of reactive code
	- In my opinion it's less complicated, but detekt thinks it's more complex 🤷 I suppressed the two checks it was throwing for that function.