### PR TITLE
Fix `.quote` not working when quote limit is reached

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/QuoteListener.kt
@@ -96,7 +96,8 @@ class QuoteListener(private val client: CommandClient) : CoroutineEventListener 
             val cmd = fullCommand.split(' ', limit = 2)
 
             if (quoteCommand.isCommandFor(cmd[0])) {
-                if (!QuoteDAO.checkRestrictions(event.guildChannel, warnDisabledGuild = false)) return
+                // Only check if quotes are enabled for this guild (silently)
+                if (!QuoteDAO.checkRestrictions(event.guildChannel, warnDisabledGuild = false, checkQuoteLimit = false)) return
 
                 val arguments = cmd.getOrNull(1) ?: ""
                 val commandEvent = CommandEvent(event, ".", arguments, client)


### PR DESCRIPTION
Fixes a problem where the dot-prefixed quote commands were checking the quote limit before executing. This caused the base quote command to not function if executed from the dot-prefix.

Closes #198 