### PR TITLE
Coroutine framework for commands

### DIFF
--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/ApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/ApplicationCommand.kt
@@ -10,11 +10,11 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button
 interface ApplicationCommand {
     val commandName: String
 
-    fun execute(event: SlashCommandInteractionEvent)
+    suspend fun execute(event: SlashCommandInteractionEvent)
 
-    fun execute(event: ButtonInteractionEvent): Boolean = false
+    suspend fun execute(event: ButtonInteractionEvent): Boolean = false
 
-    fun execute(event: ModalInteractionEvent): Boolean = false
+    suspend fun execute(event: ModalInteractionEvent): Boolean = false
 
     fun config(): CommandData
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/DiscordCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/DiscordCommand.kt
@@ -1,6 +1,10 @@
 package com.dongtronic.diabot.platforms.discord.commands
 
 import com.jagrosh.jdautilities.command.Command
+import com.jagrosh.jdautilities.command.CommandEvent
+import dev.minn.jda.ktx.events.CoroutineEventManager
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 abstract class DiscordCommand(category: Category, parent: Command?) : Command() {
     var examples = arrayOfNulls<String>(0)
@@ -12,6 +16,25 @@ abstract class DiscordCommand(category: Category, parent: Command?) : Command() 
         this.category = category
         this.parent = parent
     }
+
+    override fun execute(event: CommandEvent) {
+        // The `.injectKTX()` line in the main class changes the event manager to a CoroutineEventManager
+        val manager = event.jda.eventManager as? CoroutineEventManager
+        if (manager == null) {
+            // fallback to blocking if the event manager isn't a CoroutineEventManager for some reason
+            runBlocking {
+                launch {
+                    executeSuspend(event)
+                }
+            }
+        } else {
+            manager.launch {
+                executeSuspend(event)
+            }
+        }
+    }
+
+    open suspend fun executeSuspend(event: CommandEvent) {}
 
     override fun toString(): String {
         return if (this.parent != null) {

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleSubCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/SampleSubCommand.kt
@@ -38,7 +38,7 @@ class SampleSubCommand(category: Category, parent: Command?) : DiscordCommand(ca
             this.aliases = arrayOf("l")
         }
 
-        override fun execute(event: CommandEvent?) {
+        override fun execute(event: CommandEvent) {
             // do a thing
         }
     }
@@ -53,7 +53,7 @@ class SampleSubCommand(category: Category, parent: Command?) : DiscordCommand(ca
             this.aliases = arrayOf("a")
         }
 
-        override fun execute(event: CommandEvent?) {
+        override fun execute(event: CommandEvent) {
             // do another thing
         }
     }
@@ -68,7 +68,7 @@ class SampleSubCommand(category: Category, parent: Command?) : DiscordCommand(ca
             this.aliases = arrayOf("remove", "d", "r")
         }
 
-        override fun execute(event: CommandEvent?) {
+        override fun execute(event: CommandEvent) {
             // do the third thing
         }
     }

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConversionApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/ConversionApplicationCommand.kt
@@ -25,7 +25,7 @@ class ConversionApplicationCommand : ApplicationCommand {
                 )
     }
 
-    override fun execute(event: SlashCommandInteractionEvent) {
+    override suspend fun execute(event: SlashCommandInteractionEvent) {
         val glucoseNumber = event.getOption(commandArgGlucose)!!.asString
         val glucoseUnit = event.getOption(commandArgUnit)?.asString
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/EstimationApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/diabetes/EstimationApplicationCommand.kt
@@ -33,7 +33,7 @@ class EstimationApplicationCommand : ApplicationCommand {
         )
     }
 
-    override fun execute(event: SlashCommandInteractionEvent) {
+    override suspend fun execute(event: SlashCommandInteractionEvent) {
         when (event.subcommandName) {
             commandModeAverage -> estimateAverage(event)
             commandModeA1c -> estimateA1c(event)

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/AwyissApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/misc/AwyissApplicationCommand.kt
@@ -23,7 +23,7 @@ class AwyissApplicationCommand : ApplicationCommand {
                 .addOption(OptionType.BOOLEAN, commandArgSfw, "Safe for work", false)
     }
 
-    override fun execute(event: SlashCommandInteractionEvent) {
+    override suspend fun execute(event: SlashCommandInteractionEvent) {
         val stringValue = event.getOption(commandArgValue)!!.asString
         val sfwValue = event.getOption(commandArgSfw)?.asBoolean ?: true
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutApplicationCommand.kt
@@ -45,7 +45,7 @@ class NightscoutApplicationCommand : ApplicationCommand {
     private val commandButtonDeleteConfirm = "nsdeleteyes".generateId()
     private val commandButtonDeleteCancel = "nsdeleteno".generateId()
 
-    override fun execute(event: SlashCommandInteractionEvent) {
+    override suspend fun execute(event: SlashCommandInteractionEvent) {
         when (event.subcommandGroup) {
             groupNameSet -> when (event.subcommandName) {
                 commandModeToken -> setToken(event)
@@ -70,7 +70,7 @@ class NightscoutApplicationCommand : ApplicationCommand {
         }
     }
 
-    override fun execute(event: ButtonInteractionEvent): Boolean {
+    override suspend fun execute(event: ButtonInteractionEvent): Boolean {
         when (event.componentId) {
             commandButtonDeleteConfirm -> deleteData(event)
             commandButtonDeleteCancel -> cancelDeleteData(event)

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteAddCommand.kt
@@ -6,9 +6,7 @@ import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.dongtronic.diabot.util.logger
 import com.jagrosh.jdautilities.command.CommandEvent
 import dev.minn.jda.ktx.coroutines.await
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.runBlocking
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 
@@ -25,53 +23,49 @@ class QuoteAddCommand(category: Category, parent: QuoteCommand) : DiscordCommand
         this.examples = arrayOf(this.parent!!.name + " add \"this is a quote added manually\" - gar")
     }
 
-    override fun execute(event: CommandEvent) {
-        runBlocking {
-            launch {
-                if (!QuoteDAO.awaitCheckRestrictions(event.guildChannel, warnDisabledGuild = true)) return@launch
+    override suspend fun executeSuspend(event: CommandEvent) {
+        if (!QuoteDAO.awaitCheckRestrictions(event.guildChannel, warnDisabledGuild = true)) return
 
-                val match = quoteRegex.find(event.message.contentRaw)
-                if (match == null) {
-                    event.replyError("Could not parse quote. Please make sure you are using the correct format for this command")
-                    return@launch
-                }
+        val match = quoteRegex.find(event.message.contentRaw)
+        if (match == null) {
+            event.replyError("Could not parse quote. Please make sure you are using the correct format for this command")
+            return
+        }
 
-                val message = match.groups["message"]!!.value.trim()
-                var author = match.groups["author"]!!.value.trim()
-                var authorId = 0L
+        val message = match.groups["message"]!!.value.trim()
+        var author = match.groups["author"]!!.value.trim()
+        var authorId = 0L
 
-                val mention = mentionsRegex.matchEntire(author)
-                if (mention != null) {
-                    val uid = mention.groups["uid"]!!.value.trim().toLongOrNull()
+        val mention = mentionsRegex.matchEntire(author)
+        if (mention != null) {
+            val uid = mention.groups["uid"]!!.value.trim().toLongOrNull()
 
-                    if (uid != null) {
-                        try {
-                            val user = event.jda.retrieveUserById(uid).await()
-                            author = user.name
-                            authorId = uid
-                        } catch (ignored: Throwable) {
-                        }
-                    }
-                }
-
-                val quoteDto = QuoteDTO(
-                        guildId = event.guild.id,
-                        channelId = event.channel.id,
-                        author = author,
-                        authorId = authorId.toString(),
-                        quoterId = event.author.id,
-                        message = message,
-                        messageId = event.message.id
-                )
-
+            if (uid != null) {
                 try {
-                    val quote = QuoteDAO.getInstance().addQuote(quoteDto).awaitSingle()
-                    event.reply(createAddedMessage(event.member.asMention, quote.quoteId!!))
-                } catch (e: Throwable) {
-                    event.replyError("Could not add quote: ${e.message}")
-                    logger.warn("Unexpected error: " + e::class.simpleName + " - " + e.message)
+                    val user = event.jda.retrieveUserById(uid).await()
+                    author = user.name
+                    authorId = uid
+                } catch (ignored: Throwable) {
                 }
             }
+        }
+
+        val quoteDto = QuoteDTO(
+                guildId = event.guild.id,
+                channelId = event.channel.id,
+                author = author,
+                authorId = authorId.toString(),
+                quoterId = event.author.id,
+                message = message,
+                messageId = event.message.id
+        )
+
+        try {
+            val quote = QuoteDAO.getInstance().addQuote(quoteDto).awaitSingle()
+            event.reply(createAddedMessage(event.member.asMention, quote.quoteId!!))
+        } catch (e: Throwable) {
+            event.replyError("Could not add quote: ${e.message}")
+            logger.warn("Unexpected error: " + e::class.simpleName + " - " + e.message)
         }
     }
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteSearchCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteSearchCommand.kt
@@ -4,9 +4,7 @@ import com.dongtronic.diabot.data.mongodb.QuoteDAO
 import com.dongtronic.diabot.data.mongodb.QuoteDTO
 import com.dongtronic.diabot.platforms.discord.commands.DiscordCommand
 import com.jagrosh.jdautilities.command.CommandEvent
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.runBlocking
 import net.dv8tion.jda.api.EmbedBuilder
 import org.bson.conversions.Bson
 import org.litote.kmongo.and
@@ -28,68 +26,64 @@ class QuoteSearchCommand(category: Category, parent: QuoteCommand) : DiscordComm
         this.maxNumberOfQuotes = System.getenv().getOrDefault("QUOTE_MAX_SEARCH_DISPLAY", "10").toInt()
     }
 
-    override fun execute(event: CommandEvent) {
-        runBlocking {
-            launch {
-                if (!QuoteDAO.awaitCheckRestrictions(event.guildChannel, warnDisabledGuild = true)) return@launch
+    override suspend fun executeSuspend(event: CommandEvent) {
+        if (!QuoteDAO.awaitCheckRestrictions(event.guildChannel, warnDisabledGuild = true)) return
 
-                var args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toList()
+        var args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toList()
 
-                // Do we want one random quote from our search?
-                val random = args.getOrNull(0) == "r"
-                if (random) {
-                    args = args.slice(1 until args.size)
+        // Do we want one random quote from our search?
+        val random = args.getOrNull(0) == "r"
+        if (random) {
+            args = args.slice(1 until args.size)
+        }
+
+        if (args.isEmpty()) {
+            replyTooFewArgs(event)
+            return
+        }
+
+        // Build a list of regex filters based on the provided keywords
+        val filters: MutableList<Bson> = mutableListOf()
+        for (arg in args) {
+            val keyword = Regex.escape(arg)
+            filters += QuoteDTO::message regex "(?i)$keyword"
+        }
+
+        if (random) {
+            // Get a single, random quote
+            val quote = QuoteDAO.getInstance().getRandomQuote(event.guild.id, and(filters)).awaitSingle()
+            event.reply(createQuoteEmbed(quote))
+            return
+        }
+
+        @Suppress("SwallowedException")
+        try {
+            val quotes = QuoteDAO.getInstance().getQuotes(event.guild.id, and(filters))
+
+            // Create an embed with up to 10 quotes as fields
+            val builder = EmbedBuilder()
+            val msg = event.message.contentRaw
+            builder.setAuthor("Diabot Quote Search")
+            builder.setDescription("Command: \"$msg\"")
+
+            val quotesIter = quotes.toIterable().iterator()
+            var count = 0
+            while (quotesIter.hasNext()) {
+                val quote = quotesIter.next()
+                if (count < maxNumberOfQuotes) {
+                    // Ignore any quotes past the first 10
+                    addQuoteToEmbed(builder, quote)
                 }
-
-                if (args.isEmpty()) {
-                    replyTooFewArgs(event)
-                    return@launch
-                }
-
-                // Build a list of regex filters based on the provided keywords
-                val filters: MutableList<Bson> = mutableListOf()
-                for (arg in args) {
-                    val keyword = Regex.escape(arg)
-                    filters += QuoteDTO::message regex "(?i)$keyword"
-                }
-
-                if (random) {
-                    // Get a single, random quote
-                    val quote = QuoteDAO.getInstance().getRandomQuote(event.guild.id, and(filters)).awaitSingle()
-                    event.reply(createQuoteEmbed(quote))
-                    return@launch
-                }
-
-                @Suppress("SwallowedException")
-                try {
-                    val quotes = QuoteDAO.getInstance().getQuotes(event.guild.id, and(filters))
-
-                    // Create an embed with up to 10 quotes as fields
-                    val builder = EmbedBuilder()
-                    val msg = event.message.contentRaw
-                    builder.setAuthor("Diabot Quote Search")
-                    builder.setDescription("Command: \"$msg\"")
-
-                    val quotesIter = quotes.toIterable().iterator()
-                    var count = 0
-                    while (quotesIter.hasNext()) {
-                        val quote = quotesIter.next()
-                        if (count < maxNumberOfQuotes) {
-                            // Ignore any quotes past the first 10
-                            addQuoteToEmbed(builder, quote)
-                        }
-                        count += 1
-                    }
-
-                    if (count > maxNumberOfQuotes) {
-                        builder.addField("Too many!", "$count quotes found, omitting the rest", false)
-                    }
-
-                    event.reply(builder.build())
-                } catch (e: java.util.NoSuchElementException) {
-                    event.replyError("Could not find any quote")
-                }
+                count += 1
             }
+
+            if (count > maxNumberOfQuotes) {
+                builder.addField("Too many!", "$count quotes found, omitting the rest", false)
+            }
+
+            event.reply(builder.build())
+        } catch (e: java.util.NoSuchElementException) {
+            event.replyError("Could not find any quote")
         }
     }
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteSearchCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/quote/QuoteSearchCommand.kt
@@ -27,7 +27,7 @@ class QuoteSearchCommand(category: Category, parent: QuoteCommand) : DiscordComm
     }
 
     override suspend fun executeSuspend(event: CommandEvent) {
-        if (!QuoteDAO.awaitCheckRestrictions(event.guildChannel, warnDisabledGuild = true)) return
+        if (!QuoteDAO.awaitCheckRestrictions(event.guildChannel, warnDisabledGuild = true, checkQuoteLimit = false)) return
 
         var args = event.args.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toList()
 

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ApplicationCommandListener.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/listeners/ApplicationCommandListener.kt
@@ -2,12 +2,13 @@ package com.dongtronic.diabot.platforms.discord.listeners
 
 import com.dongtronic.diabot.platforms.discord.commands.ApplicationCommand
 import com.dongtronic.diabot.util.logger
+import dev.minn.jda.ktx.events.CoroutineEventListener
+import net.dv8tion.jda.api.events.GenericEvent
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
-import net.dv8tion.jda.api.hooks.ListenerAdapter
 
-class ApplicationCommandListener(vararg val commands: ApplicationCommand) : ListenerAdapter() {
+class ApplicationCommandListener(vararg val commands: ApplicationCommand) : CoroutineEventListener {
     private val logger = logger()
     private val commandMap: Map<String, ApplicationCommand>
 
@@ -23,7 +24,15 @@ class ApplicationCommandListener(vararg val commands: ApplicationCommand) : List
         }
     }
 
-    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+    override suspend fun onEvent(event: GenericEvent) {
+        when (event) {
+            is SlashCommandInteractionEvent -> onSlashCommandInteraction(event)
+            is ButtonInteractionEvent -> onButtonInteraction(event)
+            is ModalInteractionEvent -> onModalInteraction(event)
+        }
+    }
+
+    suspend fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
         val commandClass = commandMap[event.name]
 
         if (commandClass != null) {
@@ -34,7 +43,7 @@ class ApplicationCommandListener(vararg val commands: ApplicationCommand) : List
         }
     }
 
-    override fun onButtonInteraction(event: ButtonInteractionEvent) {
+    suspend fun onButtonInteraction(event: ButtonInteractionEvent) {
         val name = event.componentId.split(':').firstOrNull()
         val commandClass = commandMap[name]
 
@@ -44,7 +53,7 @@ class ApplicationCommandListener(vararg val commands: ApplicationCommand) : List
         }
     }
 
-    override fun onModalInteraction(event: ModalInteractionEvent) {
+    suspend fun onModalInteraction(event: ModalInteractionEvent) {
         val name = event.modalId.split(':').firstOrNull()
         val commandClass = commandMap[name]
 


### PR DESCRIPTION
This PR makes it easier and cleaner for commands to implement coroutines in the future. It also moves the current coroutine commands to use a real coroutine scope, instead of blocking the command execution thread.

It adds a default implementation for `execute()` in the `DiscordCommand` class (which all commands extend from) to call the new `executeSuspend()` function. Commands which don't use coroutines will just override this default, but coroutine commands will use `executeSuspend` which gets called in a coroutine scope when a command event occurs for it. The code tries to use the scope from jda-ktx's `CoroutineEventManager`, but it will fall back to blocking execution if the event manager isn't a coroutine one for whatever reason.

- Adds a coroutine framework for application and text commands
- Migrate existing coroutine commands to this new framework
	- Only three commands actually used coroutines: `/graph`, `diabot quote add`, and `diabot quote search`
- Fixes `diabot quote search` for #198 (I forgot there was an await version of `checkRestrictions()` and missed that usage 😬)