### PR TITLE
Support graphing 1-min interval CGMs by increasing reading limit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           chmod +x gradlew
           ./gradlew stage
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: build/libs/diabot.jar

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -35,7 +35,7 @@ jobs:
           chmod +x gradlew
           ./gradlew stage
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: build/libs/diabot.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           chmod +x gradlew
           ./gradlew stage
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: build/libs/diabot.jar

--- a/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutGraphApplicationCommand.kt
+++ b/bot/src/main/java/com/dongtronic/diabot/platforms/discord/commands/nightscout/NightscoutGraphApplicationCommand.kt
@@ -118,9 +118,7 @@ class NightscoutGraphApplicationCommand : ApplicationCommand {
                 val time = (hours ?: userDTO.graphSettings.hours)
                     .let { Duration.ofHours(it) }
 
-                // calculate the amount of readings there should be.
-                // assume 1 reading every 5 minutes and a minimum of 1 reading
-                val count = max(time.toMinutes() / 5, 1).toInt()
+                val maxReadings = max(time.toMinutes(), 1).toInt()
                 val startTime = Instant.now()
                     .minus(time)
                     .toEpochMilli()
@@ -128,7 +126,7 @@ class NightscoutGraphApplicationCommand : ApplicationCommand {
                 val findParam = EntriesParameters()
                     .find("sgv", operator = MongoOperator.exists)
                     .find("date", startTime, MongoOperator.gte)
-                    .count(count)
+                    .count(maxReadings)
                     .toMap()
                 ns.getSgv(params = findParam, throwOnConversion = false)
                     // duplicate code from NightscoutCommand. will be cleaned up later with a refactor of both


### PR DESCRIPTION
Some CGM systems provide 1 reading per minute, rather than the 1 reading per 5 minutes we currently expect. We limit the number of readings requested from the Nightscout API based on the duration to graph: `minutes / 5`. For these users, this resulted in graphs showing fewer hours than expected. This commit adjusts the limit to account for 1 reading per minute.