### PR TITLE
Fix Java versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:6.7 as build
+FROM gradle:8.14 as build
 WORKDIR /app
 COPY . .
 RUN gradle stage
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:17-alpine
 
 WORKDIR /app/
 

--- a/Dockerfile.nobuild
+++ b/Dockerfile.nobuild
@@ -1,6 +1,6 @@
 # This Dockerfile copies an already-built JAR from `./build/libs/diabot.jar` rather than building it
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:17-alpine
 
 WORKDIR /app/
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Any support received will be used to pay for the hosting and improvement of Diab
 
 ### As Java application
 
-Development for Diabot is aimed at a Java 11 environment. Diabot may not function correctly when using other version of java.
+Development for Diabot is aimed at a Java 17 environment. Diabot may not function correctly when using other version of java.
 
 If you have Gradle installed, you can run the following two commands to quickly start Diabot:
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id 'java'
@@ -48,8 +49,9 @@ allprojects {
     }
 
     kotlin {
-        targetCompatibility = JavaVersion.VERSION_17
-        sourceCompatibility = JavaVersion.VERSION_17
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_17
+        }
     }
 
     group = "com.dongtronic.diabot"


### PR DESCRIPTION
Fly.io is giving an error because the class files were compiled with a newer Java version than the JRE it's running under. The jar compiler version was changed to 17 in 3f82bea3dbb5bf1818dcb0043ff4e2c73f5ae68a, but the JRE specified in the Dockerfile was still at 11. This PR updates everything to Java 17.